### PR TITLE
Resolve Stripe Promise and remove react-stripe-js dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > A React Hook that handles shopping cart state and logic for Stripe.
 
 [![NPM](https://img.shields.io/npm/v/use-shopping-cart.svg)](https://www.npmjs.com/package/use-shopping-cart) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 
 [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
@@ -40,36 +41,29 @@ At the root level of your application (or the highest point you'll be using Stri
 When loading up Stripe, don't forget to use your public Stripe API key with it. If you need help setting up your environment variables for this, [view a list of environment variable tutorials.](#Environment-Variable-Tutorials)
 
 ```jsx
-import ReactDOM from 'react-dom'
+import ReactDOM from 'react-dom';
 
-import { loadStripe } from '@stripe/stripe-js'
-import { Elements, ElementsConsumer } from '@stripe/react-stripe-js'
-import { CartProvider } from 'use-shopping-cart'
+import { loadStripe } from '@stripe/stripe-js';
+import { CartProvider } from 'use-shopping-cart';
 
-import App from './App'
+import App from './App';
 
 // Remember to add your public Stripe key
-const stripePromise = loadStripe(process.env.REACT_APP_STRIPE_API_PUBLIC)
+const stripePromise = loadStripe(process.env.REACT_APP_STRIPE_API_PUBLIC);
 
 ReactDOM.render(
-  <Elements stripe={stripePromise}>
-    <ElementsConsumer>
-      {({ stripe }) => (
-        <CartProvider
-          stripe={stripe}
-          successUrl="stripe.com"
-          cancelUrl="twitter.com/dayhaysoos"
-          currency="USD"
-          allowedCountries={['US', 'UK', 'CA']}
-          billingAddressCollection={true}
-        >
-          <App />
-        </CartProvider>
-      )}
-    </ElementsConsumer>
-  </Elements>,
+  <CartProvider
+    stripe={stripePromise}
+    successUrl="stripe.com"
+    cancelUrl="twitter.com/dayhaysoos"
+    currency="USD"
+    allowedCountries={['US', 'UK', 'CA']}
+    billingAddressCollection={true}
+  >
+    <App />
+  </CartProvider>,
   document.getElementById('root')
-)
+);
 ```
 
 ### Using the hook
@@ -77,9 +71,9 @@ ReactDOM.render(
 The hook `useShoppingCart()` provides several utilities and pieces of data for you to use in your application. The examples below won't cover every part of the `useShoppingCart()` API but you can [look at the API](#API) below.
 
 ```jsx
-import { useShoppingCart } from 'use-shopping-cart'
-import { Product } from './Product'
-import { CartItems } from './CartItems'
+import { useShoppingCart } from 'use-shopping-cart';
+import { Product } from './Product';
+import { CartItems } from './CartItems';
 
 const productData = [
   {
@@ -96,16 +90,16 @@ const productData = [
     image: 'https://www.fillmurray.com/300/300',
     currency: 'USD',
   },
-]
+];
 
 export function App() {
   /* Gets the totalPrice and a method for redirecting to stripe */
-  const { totalPrice, redirectToCheckout, cartCount } = useShoppingCart()
+  const { totalPrice, redirectToCheckout, cartCount } = useShoppingCart();
 
   return (
     <div>
       {/* Renders the products */}
-      {productData.map(product => (
+      {productData.map((product) => (
         <Product product={product} />
       ))}
 
@@ -117,7 +111,7 @@ export function App() {
       {/* Redirects the user to Stripe */}
       <button onClick={redirectToCheckout}>Checkout</button>
     </div>
-  )
+  );
 }
 ```
 
@@ -126,17 +120,17 @@ export function App() {
 To add a product to the cart, use `useShoppingCart()`'s `addItem(product)` method. It takes in your product object, which must have a `sku` and a `price`, and adds it to the cart.
 
 ```jsx
-import { useShoppingCart, toCurrency } from 'use-shopping-cart'
+import { useShoppingCart, toCurrency } from 'use-shopping-cart';
 
 export function Product({ product }) {
-  const { addItem } = useShoppingCart()
+  const { addItem } = useShoppingCart();
 
   /* A helper function that turns the price into a readable format */
   const price = toCurrency({
-    price: product.price,
+    value: product.price,
     currency: product.currency,
     language: navigator.language,
-  })
+  });
 
   return (
     <article>
@@ -150,9 +144,11 @@ export function Product({ product }) {
       <button
         onClick={() => addItem(product)}
         aria-label={`Add ${product.name} to your cart`}
-      >Add to cart</button>
+      >
+        Add to cart
+      </button>
     </article>
-  )
+  );
 }
 ```
 
@@ -161,7 +157,6 @@ export function Product({ product }) {
 Once the user has added their items to the cart, you can use the `cartDetails` object to display the different data about each product in their cart.
 
 Each product in `cartDetails` contains the same data you provided when you called `addItem(product)`. In addition, `cartDetails` also provides the following properties:
-
 
 <table>
   <tr>
@@ -183,20 +178,20 @@ Each product in `cartDetails` contains the same data you provided when you calle
 </table>
 
 ```jsx
-import { useShoppingCart } from 'use-shopping-cart'
+import { useShoppingCart } from 'use-shopping-cart';
 
 export function CartItems() {
   const {
     cartDetails,
     reduceItemByOne,
     addItem,
-    removeCartItem
-  } = useShoppingCart()
+    removeCartItem,
+  } = useShoppingCart();
 
-  const cart = []
+  const cart = [];
   // Note: Object.keys().map() takes 2x as long as a for-in loop
   for (const sku in cartDetails) {
-    const cartEntry = cartDetails[sku]
+    const cartEntry = cartDetails[sku];
 
     // all of your basic product data still exists (i.e. name, image, price)
     cart.push(
@@ -209,20 +204,26 @@ export function CartItems() {
         <button
           onClick={() => reduceItemByOne(cartEntry.sku)}
           aria-label={`Remove one ${cartEntry.name} from your cart`}
-        >-</button>
+        >
+          -
+        </button>
         <p>Quantity: {cartEntry.quantity}</p>
         <button
           onClick={() => addItem(cartEntry)}
           aria-label={`Add one ${cartEntry.name} to your cart`}
-        >+</button>
+        >
+          +
+        </button>
 
         {/* What if we don't want this product at all */}
         <button
           onClick={() => removeCartItem(cartEntry.sku)}
           aria-label={`Remove all ${cartEntry.name} from your cart`}
-        >Remove</button>
+        >
+          Remove
+        </button>
       </article>
-    )
+    );
   }
 
   return cart;
@@ -232,19 +233,19 @@ export function CartItems() {
 Note that in the above code, to reduce the quantity of a product in the user's cart, you must pass an SKU to `reduceItemByOne()` like so:
 
 ```js
-reduceItemByOne(cartEntry.sku)
+reduceItemByOne(cartEntry.sku);
 ```
 
 Just like you can reduce the quantity of a product you can remove the product entirely with `removeCartItem()`:
 
 ```js
-removeCartItem(cartEntry.sku)
+removeCartItem(cartEntry.sku);
 ```
 
 However, those two examples differ from the way that you increase the quantity of a product in the user's cart. Currently, to do this, you must pass the entire `cartEntry` to `addItem()`:
 
 ```js
-addItem(cartEntry)
+addItem(cartEntry);
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 ## Installation
 
 ```bash
-npm install --save use-shopping-cart
+npm install --save @stripe/stripe-js use-shopping-cart
 
 # or
 
-yarn add use-shopping-cart
+yarn add @stripe/stripe-js use-shopping-cart
 ```
 
 ## Development

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -4,13 +4,12 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@stripe/react-stripe-js": "1.1.2",
     "@stripe/stripe-js": "1.4.0",
-    "stripe": "8.46.0",
     "prop-types": "15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-scripts": "3.4.1",
+    "stripe": "8.46.0",
     "theme-ui": "0.3.1",
     "use-shopping-cart": "*"
   },

--- a/examples/cra/src/index.js
+++ b/examples/cra/src/index.js
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 import { jsx } from 'theme-ui';
 import ReactDOM from 'react-dom';
-import { Elements, ElementsConsumer } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { CartProvider } from 'use-shopping-cart';
 import './index.css';
@@ -10,20 +9,14 @@ import App from './App';
 const stripePromise = loadStripe(process.env.REACT_APP_STRIPE_API_PUBLIC);
 
 ReactDOM.render(
-  <Elements stripe={stripePromise}>
-    <ElementsConsumer>
-      {({ stripe }) => (
-        <CartProvider
-          stripe={stripe}
-          billingAddressCollection={false}
-          successUrl={'https://stripe.com'}
-          cancelUrl={'https://twitter.com/dayhaysoos'}
-          currency={'USD'}
-        >
-          <App />
-        </CartProvider>
-      )}
-    </ElementsConsumer>
-  </Elements>,
+  <CartProvider
+    stripe={stripePromise}
+    billingAddressCollection={false}
+    successUrl={'https://stripe.com'}
+    cancelUrl={'https://twitter.com/dayhaysoos'}
+    currency={'USD'}
+  >
+    <App />
+  </CartProvider>,
   document.getElementById('root')
 );

--- a/use-shopping-cart/src/index.js
+++ b/use-shopping-cart/src/index.js
@@ -271,7 +271,9 @@ export const useShoppingCart = () => {
       throw new Error('Stripe is not defined');
     }
 
-    const { error } = await stripe.redirectToCheckout(
+    const resolvedStripe = await Promise.resolve(stripe);
+
+    const { error } = await resolvedStripe.redirectToCheckout(
       sessionId ? sessionId : options
     );
     if (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,13 +1861,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@stripe/react-stripe-js@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@stripe/react-stripe-js/-/react-stripe-js-1.1.2.tgz#a7f5ef5b4d7dc7fa723501b706644414cfe6dcba"
-  integrity sha512-07hu8RJXwWKGbvdvd1yt1cYvGtDB8jFX+q10f7FQuItUt9rlSo0am3WIx845iMHANiYgxyRb1PS201Yle9xxPQ==
-  dependencies:
-    prop-types "^15.7.2"
-
 "@stripe/stripe-js@1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@stripe/stripe-js/-/stripe-js-1.4.0.tgz#287b0fb653d9a34321dfa8b52f8c99b7983f2eda"


### PR DESCRIPTION
r? @dayhaysoos 

* When using Stripe Checkout we don't need the `react-stripe-js` library
* Change `CartProvider` to be able to accept both the `stripePromise` and the stripe object. 

This allows us to remove unnecessary usage of react-stripe-js when using Checkout, but allows us to also allows us to keep the door open to usage with Elements in the future.

TODO: 

- [x] update docs at https://use-shopping-cart.netlify.app/getting-started