### PR TITLE
Format non-decimal currencies correctly

### DIFF
--- a/use-shopping-cart/src/util.js
+++ b/use-shopping-cart/src/util.js
@@ -3,11 +3,24 @@ import { useStorageReducer } from 'react-storage-hooks';
 export const isClient = typeof window === 'object';
 
 export const toCurrency = ({ value, currency, language }) => {
-  const formatted = new Intl.NumberFormat(language, {
-    style: 'currency',
-    currency,
-  }).format(value / 100);
-  return formatted;
+  value = parseInt(value);
+  const numberFormat = new Intl.NumberFormat(
+    language ?? window?.navigator.language ?? 'en-US',
+    {
+      style: 'currency',
+      currency,
+      currencyDisplay: 'symbol',
+    }
+  );
+  const parts = numberFormat.formatToParts(value);
+  let zeroDecimalCurrency = true;
+  for (const part of parts) {
+    if (part.type === 'decimal') {
+      zeroDecimalCurrency = false;
+    }
+  }
+  value = zeroDecimalCurrency ? value : value / 100;
+  return numberFormat.format(value.toFixed(2));
 };
 
 export const calculateTotalValue = (currency, cartItems) => {

--- a/use-shopping-cart/src/util.test.js
+++ b/use-shopping-cart/src/util.test.js
@@ -37,4 +37,11 @@ describe('calculateTotalValue', () => {
 
     expect(calculateTotalValue('USD', cartItems)).toBe('$3.00');
   });
+
+  it('handles non-decimal currencies', () => {
+    const cartItems = [{ price: 100 }, { price: 100 }];
+
+    expect(calculateTotalValue('JPY', cartItems)).toBe('¥200');
+    expect(calculateTotalValue('MGA', cartItems)).toBe('MGA 200');
+  });
 });


### PR DESCRIPTION
r? @dayhaysoos 

* Some currencies don't have decimals: https://stripe.com/docs/currencies#zero-decimal. We need to take that into account when formatting with `toCurrency()`
* Change `toCurrency()` to default to `en-US` if neither language var now window is defined (e.g. when running the test suite)

**Questions**: Would you be open to renaming `toCurrency()` to either `toCurrencyString()` or my preferred `formatCurrencyString()`? To me `toCurrency()` sounds more like a currency conversion helper.