### PR TITLE
Fix validateCartItems

### DIFF
--- a/use-shopping-cart/src/serverUtil.js
+++ b/use-shopping-cart/src/serverUtil.js
@@ -9,7 +9,7 @@ const validateCartItems = (inventorySrc, cartDetails) => {
     )
     validatedItems.push({
       name: validatedItem.name,
-      amount: validatedItem.price * product.quantity,
+      amount: validatedItem.price,
       currency: validatedItem.currency,
       quantity: product.quantity
     })


### PR DESCRIPTION
@dayhaysoos Stripe automatically multiplies by the quantity so we need to set the base amount of the sku.