### PR TITLE
Refactor checkout handling to abstract specifics + errors

### DIFF
--- a/use-shopping-cart/src/index.js
+++ b/use-shopping-cart/src/index.js
@@ -1,16 +1,16 @@
 import React, {
   createContext,
-  useReducer,
   useContext,
+  useEffect,
   useMemo,
-  useEffect
+  useReducer
 } from 'react'
 
 import {
-  useLocalStorageReducer,
+  checkoutHandler,
+  formatCurrencyString,
   isClient,
-  getCheckoutData,
-  formatCurrencyString
+  useLocalStorageReducer
 } from './util'
 import {
   cartInitialState,
@@ -97,14 +97,8 @@ export const useShoppingCart = () => {
   const [cart, dispatch] = useContext(CartContext)
 
   const {
-    mode,
-    stripe,
     lastClicked,
     shouldDisplayCart,
-    successUrl,
-    cancelUrl,
-    billingAddressCollection,
-    allowedCountries,
     cartCount,
     cartDetails,
     totalPrice,
@@ -129,63 +123,20 @@ export const useShoppingCart = () => {
   const handleCartHover = () => dispatch({ type: 'cart-hover' })
   const handleCloseCart = () => dispatch({ type: 'close-cart' })
 
-  async function redirectToCheckout(sessionId) {
-    if (stripe === null) throw new Error('Stripe is not defined')
-    const resolvedStripe = await Promise.resolve(stripe)
-
-    if (mode === 'client-only') {
-      // client-only checkout mode
-      const options = {
-        items: getCheckoutData.stripe(cart),
-        successUrl,
-        cancelUrl,
-        billingAddressCollection: billingAddressCollection
-          ? 'required'
-          : 'auto',
-        submitType: 'auto'
-      }
-
-      if (allowedCountries?.length)
-        options.shippingAddressCollection = { allowedCountries }
-
-      const { error } = await resolvedStripe.redirectToCheckout(options)
-      if (error) return error
-    } else if (mode === 'checkout-session') {
-      // checkout-session mode
-      const { error } = await resolvedStripe.redirectToCheckout(sessionId)
-      if (error) return error
-    } else {
-      throw new Error(
-        `Invalid checkout mode '${mode}' was chosen. Valid options are 'client-only' and 'checkout-session'`
-      )
+  const redirectToCheckout = checkoutHandler(cart, {
+    modes: ['client-only', 'checkout-session'],
+    stripe(stripe, options) {
+      return stripe.redirectToCheckout(options)
     }
-  }
+  })
 
-  async function checkoutSingleItem({ sku, quantity = 1 }) {
-    const resolvedStripe = await Promise.resolve(stripe)
-
-    if (mode === 'client-only') {
-      const options = {
-        items: [{ sku, quantity }],
-        successUrl,
-        cancelUrl,
-        billingAddressCollection: billingAddressCollection
-          ? 'required'
-          : 'auto',
-        submitType: 'auto'
-      }
-
-      if (allowedCountries?.length)
-        options.shippingAddressCollection = { allowedCountries }
-
-      const { error } = await resolvedStripe.redirectToCheckout(options)
-      if (error) return error
-    } else {
-      throw new Error(
-        `Invalid checkout mode '${mode}' was chosen. The only option for single-item checkout is 'client-only'`
-      )
+  const checkoutSingleItem = checkoutHandler(cart, {
+    modes: ['client-only'],
+    stripe(stripe, options, { sku, quantity = 1 }) {
+      options.items = [{ sku, quantity }]
+      return stripe.redirectToCheckout(options)
     }
-  }
+  })
 
   return {
     cartDetails,

--- a/use-shopping-cart/src/index.test.js
+++ b/use-shopping-cart/src/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import { renderHook, act } from '@testing-library/react-hooks'
-import { useShoppingCart, CartProvider } from './index'
+import { act, renderHook } from '@testing-library/react-hooks'
+import { CartProvider, useShoppingCart } from './index'
 
 afterEach(() => window.localStorage.clear())
 
@@ -479,10 +479,10 @@ describe('redirectToCheckout()', () => {
     const cart = renderHook(() => useShoppingCart(), { wrapper }).result
 
     const expectedSessionId = 'bloo-bleh-blah-1234'
-    await cart.current.redirectToCheckout(expectedSessionId)
+    await cart.current.redirectToCheckout({ sessionId: expectedSessionId })
 
     expect(stripeMock.redirectToCheckout).toHaveBeenCalled()
-    expect(stripeMock.redirectToCheckout.mock.calls[0][0]).toBe(
+    expect(stripeMock.redirectToCheckout.mock.calls[0][0].sessionId).toBe(
       expectedSessionId
     )
   })
@@ -493,20 +493,21 @@ describe('redirectToCheckout()', () => {
     const cart = renderHook(() => useShoppingCart(), { wrapper }).result
 
     expect(cart.current.redirectToCheckout()).rejects.toThrow(
-      `Invalid checkout mode '${mode}' was chosen. Valid options are 'client-only' and 'checkout-session'`
+      `Invalid checkout mode '${mode}' was chosen. The valid modes are client-only and checkout-session.`
     )
   })
 })
 
 describe('checkoutSingleItem()', () => {
+  let cart
   beforeEach(() => {
     stripeMock.redirectToCheckout.mockClear()
+
+    const wrapper = createWrapper()
+    cart = renderHook(() => useShoppingCart(), { wrapper }).result
   })
 
   it('should send the formatted item with no quantity parameter', async () => {
-    const wrapper = createWrapper()
-    const cart = renderHook(() => useShoppingCart(), { wrapper }).result
-
     const product = mockProduct()
     await cart.current.checkoutSingleItem({ sku: product.sku })
 
@@ -517,9 +518,6 @@ describe('checkoutSingleItem()', () => {
   })
 
   it('should send the formatted item with a custom quantity parameter', async () => {
-    const wrapper = createWrapper()
-    const cart = renderHook(() => useShoppingCart(), { wrapper }).result
-
     const product = mockProduct()
     await cart.current.checkoutSingleItem({ sku: product.sku, quantity: 47 })
 
@@ -527,6 +525,18 @@ describe('checkoutSingleItem()', () => {
     expect(stripeMock.redirectToCheckout.mock.calls[0][0].items).toEqual([
       { sku: product.sku, quantity: 47 }
     ])
+  })
+
+  it('does not support checkout-session mode', async () => {
+    const wrapper = createWrapper({ mode: 'checkout-session' })
+    cart = renderHook(() => useShoppingCart(), { wrapper }).result
+
+    const product = mockProduct()
+    expect(
+      cart.current.checkoutSingleItem({ sku: product.sku })
+    ).rejects.toThrow(
+      "Invalid checkout mode 'checkout-session' was chosen. The valid modes are client-only."
+    )
   })
 })
 
@@ -543,7 +553,7 @@ describe('stripe handling', () => {
     const cart = renderHook(() => useShoppingCart(), { wrapper }).result
 
     expect(cart.current.redirectToCheckout()).rejects.toThrow(
-      'Stripe is not defined'
+      'No compatible API has been defined, your options are: Stripe'
     )
   })
 })

--- a/use-shopping-cart/src/util.js
+++ b/use-shopping-cart/src/util.js
@@ -15,11 +15,14 @@ export const formatCurrencyString = ({
   })
   const parts = numberFormat.formatToParts(value)
   let zeroDecimalCurrency = true
+
   for (const part of parts) {
     if (part.type === 'decimal') {
       zeroDecimalCurrency = false
+      break
     }
   }
+
   value = zeroDecimalCurrency ? value : value / 100
   return numberFormat.format(value.toFixed(2))
 }
@@ -42,10 +45,61 @@ export function useLocalStorageReducer(key, reducer, initialState) {
 
 export const getCheckoutData = {
   stripe(cart) {
-    const checkoutData = []
-    for (const sku in cart.cartDetails) {
-      checkoutData.push({ sku, quantity: cart.cartDetails[sku].quantity })
+    const items = []
+    for (const sku in cart.cartDetails)
+      items.push({ sku, quantity: cart.cartDetails[sku].quantity })
+
+    const options = {
+      items,
+      successUrl: cart.successUrl,
+      cancelUrl: cart.cancelUrl,
+      billingAddressCollection: cart.billingAddressCollection
+        ? 'required'
+        : 'auto',
+      submitType: 'auto'
     }
-    return checkoutData
+
+    if (cart.allowedCountries?.length) {
+      options.shippingAddressCollection = {
+        allowedCountries: cart.allowedCountries
+      }
+    }
+
+    return options
+  }
+}
+
+export function checkoutHandler(cart, checkoutOptions) {
+  let serviceProperty = ''
+  if (cart.stripe) serviceProperty = 'stripe'
+
+  const needsCheckoutData = cart.mode === 'client-only'
+
+  return async function (parameters) {
+    if (!serviceProperty) {
+      throw new Error(
+        'No compatible API has been defined, your options are: Stripe'
+      )
+    }
+
+    if (!checkoutOptions.modes.includes(cart.mode)) {
+      throw new Error(
+        `Invalid checkout mode '${
+          cart.mode
+        }' was chosen. The valid modes are ${new Intl.ListFormat().format(
+          checkoutOptions.modes
+        )}.`
+      )
+    }
+
+    let options = { sessionId: parameters?.sessionId }
+    if (needsCheckoutData) options = getCheckoutData.stripe(cart)
+
+    const { error } = await checkoutOptions[serviceProperty](
+      await cart[serviceProperty],
+      options,
+      parameters
+    )
+    if (error) return error
   }
 }

--- a/use-shopping-cart/src/util.test.js
+++ b/use-shopping-cart/src/util.test.js
@@ -8,15 +8,23 @@ describe('getCheckoutData', () => {
       sku3: { quantity: 3, price: 50 }
     },
     totalPrice: 550, // 100 * 1 + 150 * 2 + 50 * 3
-    cartCount: 6
+    cartCount: 6,
+    successUrl: 'https://example.com/sucess',
+    cancelUrl: 'https://example.com/'
   }
 
   it('stripe()', () => {
-    expect(getCheckoutData.stripe(cart)).toEqual([
-      { sku: 'sku1', quantity: 1 },
-      { sku: 'sku2', quantity: 2 },
-      { sku: 'sku3', quantity: 3 }
-    ])
+    expect(getCheckoutData.stripe(cart)).toEqual({
+      billingAddressCollection: 'auto',
+      successUrl: cart.successUrl,
+      cancelUrl: cart.cancelUrl,
+      items: [
+        { quantity: 1, sku: 'sku1' },
+        { quantity: 2, sku: 'sku2' },
+        { quantity: 3, sku: 'sku3' }
+      ],
+      submitType: 'auto'
+    })
   })
 })
 


### PR DESCRIPTION
This PR refactors the methods `redirectToCheckout()` and `checkoutSingleItem()` to pretty much all duplication between the two.

This is done by:

- moving the building of the `options` for Stripe's `redirectToCheckout` into `getCheckoutData.stripe()`.
- making a method called `checkoutHandler` that:
  - throws errors when it determines that:
    - no API service has been attached to the cart that we can use (i.e. `stripe`)
    - an invalid checkout mode was used with that checkout handler based on the modes passed to `checkoutHandler()`
  - gets the checkout data when in `'client-only'` mode but gives the `sessionId` when in `checkout-session` mode

How this looks now:

```js
const redirectToCheckout = checkoutHandler(cart, {
  modes: ['client-only', 'checkout-session'],
  stripe(stripe, options) {
    return stripe.redirectToCheckout(options)
  }
})

const checkoutSingleItem = checkoutHandler(cart, {
  modes: ['client-only'],
  stripe(stripe, options, { sku, quantity = 1 }) {
    options.items = [{ sku, quantity }]
    return stripe.redirectToCheckout(options)
  }
})
```

The third parameter for the handlers is the arguments passed to `cart.redirectToCheckout()` or `cart.checkoutSingleItem()`

This should allow us to more easily support other services like [Shopify's StoreFront API](https://shopify.dev/docs/storefront-api/getting-started) or [Network Merchants' CollectCheckout](https://secure.networkmerchants.com/gw/merchants/resources/integration/integration_portal.php#cc_integration) (their landing page is https://nmi.com)