### PR TITLE
Migrate to prices for client-only mode

### DIFF
--- a/use-shopping-cart/src/index.js
+++ b/use-shopping-cart/src/index.js
@@ -136,7 +136,8 @@ export const useShoppingCart = () => {
     if (mode === 'client-only') {
       // client-only checkout mode
       const options = {
-        items: getCheckoutData.stripe(cart),
+        mode: 'payment',
+        lineItems: getCheckoutData.stripe(cart),
         successUrl,
         cancelUrl,
         billingAddressCollection: billingAddressCollection

--- a/use-shopping-cart/src/index.test.js
+++ b/use-shopping-cart/src/index.test.js
@@ -417,7 +417,8 @@ describe('redirectToCheckout()', () => {
 
     expect(stripeMock.redirectToCheckout).toHaveBeenCalled()
     expect(stripeMock.redirectToCheckout.mock.calls[0][0]).toEqual({
-      items: [{ sku: product.sku, quantity: 1 }],
+      mode: 'payment',
+      lineItems: [{ price: product.sku, quantity: 1 }],
       successUrl: 'https://egghead.io/success',
       cancelUrl: 'https://egghead.io/cancel',
       billingAddressCollection: 'auto',
@@ -439,12 +440,12 @@ describe('redirectToCheckout()', () => {
     await cart.current.redirectToCheckout()
 
     const expectedItems = [
-      { sku: product1.sku, quantity: 2 },
-      { sku: product2.sku, quantity: 9 }
+      { price: product1.sku, quantity: 2 },
+      { price: product2.sku, quantity: 9 }
     ]
 
     expect(stripeMock.redirectToCheckout).toHaveBeenCalled()
-    expect(stripeMock.redirectToCheckout.mock.calls[0][0].items).toEqual(
+    expect(stripeMock.redirectToCheckout.mock.calls[0][0].lineItems).toEqual(
       expectedItems
     )
   })

--- a/use-shopping-cart/src/util.js
+++ b/use-shopping-cart/src/util.js
@@ -44,7 +44,10 @@ export const getCheckoutData = {
   stripe(cart) {
     const checkoutData = []
     for (const sku in cart.cartDetails) {
-      checkoutData.push({ sku, quantity: cart.cartDetails[sku].quantity })
+      checkoutData.push({
+        price: sku,
+        quantity: cart.cartDetails[sku].quantity
+      })
     }
     return checkoutData
   }

--- a/use-shopping-cart/src/util.test.js
+++ b/use-shopping-cart/src/util.test.js
@@ -13,9 +13,9 @@ describe('getCheckoutData', () => {
 
   it('stripe()', () => {
     expect(getCheckoutData.stripe(cart)).toEqual([
-      { sku: 'sku1', quantity: 1 },
-      { sku: 'sku2', quantity: 2 },
-      { sku: 'sku3', quantity: 3 }
+      { price: 'sku1', quantity: 1 },
+      { price: 'sku2', quantity: 2 },
+      { price: 'sku3', quantity: 3 }
     ])
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -19869,6 +19869,15 @@ urql@^1.9.7:
     "@urql/core" "^1.11.0"
     wonka "^4.0.9"
 
+use-shopping-cart@2.0.0:
+  version "1.1.4"
+  resolved "https://npm-registry.local.corp.stripe.com/use-shopping-cart/-/use-shopping-cart-1.1.4.tgz#5fc60952f3a528f6e9415e4fa986fd5d6137b17b"
+  integrity sha512-Oxq7WRuczD84AtbXfE26g/BjaSRf5V1cNRQyb5HXwLEYcSaJjWfrwu0OhMpUrp6MW95v7mA/e9f5lCFmgoHqEA==
+  dependencies:
+    "@types/stripe-v3" "^3.1.17"
+    prop-types "^15.7.2"
+    react-storage-hooks "^4.0.0"
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
r? @dayhaysoos 

Any idea why it considers the whole file as changes? Is it because of `yarn format`?

https://stripe.com/docs/payments/checkout/migrating-prices#one-time-payments-changes