### PR TITLE
docs(priceId): add an explanation for price id

### DIFF
--- a/documentation/src/docs/getting-started.mdx
+++ b/documentation/src/docs/getting-started.mdx
@@ -95,7 +95,7 @@ Once you have successfully installed `stripe`, `use-shopping-cart`, and wrapped 
 
 ### ⚠️ HEADS UP!
 
-You may not be able to see the SKUs section in your products but a **Prices** section. If that's the case, you can use the price ID (i.e. `price_abcd1234`) as the `sku` property in your inventory.
+You may not be able to see the SKUs section in your products on Stripe but a **Prices** section instead. If that's the case, you can use the price ID (i.e. `price_abcd1234`) as the `sku` property in your inventory.
 
 ```js
 const productData = [

--- a/documentation/src/docs/getting-started.mdx
+++ b/documentation/src/docs/getting-started.mdx
@@ -95,7 +95,7 @@ Once you have successfully installed `stripe`, `use-shopping-cart`, and wrapped 
 
 ### ⚠️ HEADS UP!
 
-You may not be able to see the SKUs section in your products but a `Prices` section. If that's the case, you can use the price ID (with this shape: `price_abcd1234`) as the sku in yout inventory
+You may not be able to see the SKUs section in your products but a **Prices** section. If that's the case, you can use the price ID (i.e. `price_abcd1234`) as the `sku` property in your inventory.
 
 ```js
 const productData = [

--- a/documentation/src/docs/getting-started.mdx
+++ b/documentation/src/docs/getting-started.mdx
@@ -91,7 +91,7 @@ export function App() {
 }
 ```
 
-Once you have successfully installed `stripe` and `use-shopping-cart` and wrap your root component with CartProvider, you are ready to go! 🚀
+Once you have successfully installed `stripe`, `use-shopping-cart`, and wrapped your root component with `<CartProvider>`, you are ready to go! 🚀
 
 ### ⚠️ HEADS UP!
 

--- a/documentation/src/docs/getting-started.mdx
+++ b/documentation/src/docs/getting-started.mdx
@@ -92,3 +92,19 @@ export function App() {
 ```
 
 Once you have successfully installed `stripe` and `use-shopping-cart` and wrap your root component with CartProvider, you are ready to go! 🚀
+
+### ⚠️ HEADS UP!
+
+You may not be able to see the SKUs section in your products but a `Prices` section. If that's the case, you can use the price ID (with this shape: `price_abcd1234`) as the sku in yout inventory
+
+```js
+const productData = [
+  {
+    name: 'Bananas',
+    sku: 'price_GBJ2Ep8246qeeT', // 👈
+    price: 400,
+    image: 'https://www.fillmurray.com/300/300',
+    currency: 'USD'
+  }
+]
+```


### PR DESCRIPTION
add a simple explanation on the price id change on the `Getting started` docs:

<img width="1220" alt="use-shopping-cart-docs-price-id" src="https://user-images.githubusercontent.com/725120/83469225-61fd1800-a47f-11ea-9d4f-9fdead00a856.png">

❓Do you think this section should be somewhere else?
❓Do you think we should add a screenshot from the Stripe dashboard?