### PR TITLE
Fix Types

### DIFF
--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -72,7 +72,6 @@
     "rollup-plugin-url": "^3.0.1"
   },
   "dependencies": {
-    "@types/stripe-v3": "^3.1.17",
     "react-storage-hooks": "^4.0.0"
   }
 }

--- a/use-shopping-cart/src/index.d.ts
+++ b/use-shopping-cart/src/index.d.ts
@@ -2,9 +2,11 @@ declare module 'use-shopping-cart' {
   interface CommonProviderProps {
     children: JSX.Element
     /**
-     * The stripe instance
+     * The stripe instance or a Promise that resolves with a Stripe instance
      */
-    stripe: stripe.Stripe
+    stripe:
+      | import('@stripe/stripe-js').Stripe
+      | Promise<import('@stripe/stripe-js').Stripe | null>
     /**
      * The preferred currency used to format price data
      */
@@ -151,11 +153,11 @@ declare module 'use-shopping-cart' {
     readonly cartDetails: CartDetails
     /**
      * Redirects customers to the Stripe checkout
-     * @param options {{ sessionId?: string }} only used in CheckoutSession mode
+     * @param options {{ sessionId: string }} only used in CheckoutSession mode
      * @returns Nothing or an error wrapped in a promise if an error occurred
      */
-    redirectToCheckout: (options: {
-      sessionId?: string
+    redirectToCheckout: (options?: {
+      sessionId: string
     }) => Promise<undefined | Error>
     /**
      * Redirects customers to the Stripe checkout

--- a/use-shopping-cart/src/serverUtil.d.ts
+++ b/use-shopping-cart/src/serverUtil.d.ts
@@ -1,0 +1,6 @@
+import * as useShoppingCart from 'use-shopping-cart';
+import Stripe from 'stripe'
+
+declare module 'use-shopping-cart/src/serverUtil' {
+  export function validateCartItems(inventory: useShoppingCart.Product[], cartItems: useShoppingCart.CartDetails): Stripe.Checkout.SessionCreateParams.LineItem[];
+}

--- a/use-shopping-cart/src/serverUtil.d.ts
+++ b/use-shopping-cart/src/serverUtil.d.ts
@@ -1,6 +1,9 @@
-import * as useShoppingCart from 'use-shopping-cart';
+import * as useShoppingCart from 'use-shopping-cart'
 import Stripe from 'stripe'
 
 declare module 'use-shopping-cart/src/serverUtil' {
-  export function validateCartItems(inventory: useShoppingCart.Product[], cartItems: useShoppingCart.CartDetails): Stripe.Checkout.SessionCreateParams.LineItem[];
+  export function validateCartItems(
+    inventory: useShoppingCart.Product[],
+    cartItems: useShoppingCart.CartDetails
+  ): Stripe.Checkout.SessionCreateParams.LineItem[]
 }

--- a/use-shopping-cart/src/serverUtil.js
+++ b/use-shopping-cart/src/serverUtil.js
@@ -5,6 +5,7 @@ const validateCartItems = (inventorySrc, cartDetails) => {
     const inventoryItem = inventorySrc.find(
       (currentProduct) => currentProduct.sku === sku
     )
+    if (!inventoryItem) throw new Error(`Product ${sku} not found!`)
     const item = {
       name: inventoryItem.name,
       amount: inventoryItem.price,

--- a/use-shopping-cart/src/serverUtil.test.js
+++ b/use-shopping-cart/src/serverUtil.test.js
@@ -79,4 +79,9 @@ describe('validateCartItems', () => {
       }
     ])
   })
+  it('throws an error if product does not exist in inventory', () => {
+    expect(() => {
+      validateCartItems(inventory, { sku_1234: { sku: 'sku_1234' } })
+    }).toThrow('Product sku_1234 not found!')
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2976,11 +2976,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/stripe-v3@^3.1.17":
-  version "3.1.17"
-  resolved "https://registry.yarnpkg.com/@types/stripe-v3/-/stripe-v3-3.1.17.tgz#0fd3c4b134daa1cd61631f58eeb6d756e0377668"
-  integrity sha512-ZnADc7cgvrnRpz9lkENMgMhBWYR6ybz/745WYPlKZZXzU05ZaADRRtafPfZDTpQhALLpX/KYKmWN/j9GmbIg4g==
-
 "@types/testing-library__react-hooks@^3.0.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.2.0.tgz#52f3a109bef06080e3b1e3ae7ea1c014ce859897"
@@ -19938,14 +19933,6 @@ urql@^1.9.7:
   dependencies:
     "@urql/core" "^1.11.0"
     wonka "^4.0.9"
-
-use-shopping-cart@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/use-shopping-cart/-/use-shopping-cart-2.0.0.tgz#a282159853afd1a80832a3a4bc67d1269888454e"
-  integrity sha512-rxKhfxQA35PKknhN0ueLs9+FzjtEV8BFrseLuEi+ay6bkYUhOlUDyNfdKCBbd6CjeROFtp5JcBiXsCKApllE3A==
-  dependencies:
-    "@types/stripe-v3" "^3.1.17"
-    react-storage-hooks "^4.0.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
- Remove `@types/stripe-v3` as `@stripe/stripe-js` ships with types
- Allow promise for the `stripe` prop on `CartProvider`
- Fix `redirectToCheckout` options

I'm working on a TypeScript example here: https://github.com/thorsten-stripe/next.js/tree/thor/stripe/add-use-shopping-cart-example/examples/with-stripe-typescript

One thing that's missing is Types for `serverUtil` which throws a warning when you use it in your TypeScript project. I'll look into that tmr.