### PR TITLE
Update old links to documentation and fix redirect

### DIFF
--- a/documentation/gatsby-config.js
+++ b/documentation/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = {
     siteTitleShort: `use-shopping-cart`,
     siteDescription:
       'React Hooks library for your Stripe powered shopping cart needs!',
-    siteUrl: `https://use-shopping-cart.netlify.app/`,
+    siteUrl: `https://useshoppingcart.com/`,
     siteAuthor: `use-shopping-cart`,
     siteImage: `/banner.png`,
     siteLanguage: `en`,
@@ -44,7 +44,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-canonical-urls`,
       options: {
-        siteUrl: `https://use-shopping-cart.netlify.app`
+        siteUrl: `https://useshoppingcart.com`
       }
     },
     `gatsby-plugin-offline`

--- a/documentation/gatsby-ssr.js
+++ b/documentation/gatsby-ssr.js
@@ -8,8 +8,8 @@ export const wrapRootElement = ({ element }) => {
   return (
     <CartProvider
       stripe={stripePromise}
-      successUrl={`https://use-shopping-cart.netlify.app/`}
-      cancelUrl={`https://use-shopping-cart.netlify.app/`}
+      successUrl={`https://useshoppingcart.com/`}
+      cancelUrl={`https://useshoppingcart.com/`}
       currency={'USD'}
       allowedCountries={['US', 'GB', 'CA']}
       billingAddressCollection={true}

--- a/documentation/netlify.toml
+++ b/documentation/netlify.toml
@@ -2,3 +2,8 @@
   from = "https://use-shopping-cart.netlify.app"
   to = "https://useshoppingcart.com"
   status = 301
+
+  [[redirects]]
+  from = "https://use-shopping-cart.netlify.app/*"
+  to = "https://useshoppingcart.com/:splat"
+  status = 301

--- a/examples/gatsby/src/pages/index.js
+++ b/examples/gatsby/src/pages/index.js
@@ -16,8 +16,7 @@ const CartExample = () => (
     <SEO title="Cart Example" />
     <h1>Checkout with cart example</h1>
     <h2>
-      With{' '}
-      <a href="https://use-shopping-cart.netlify.app/">use-shopping-cart</a>
+      With <a href="https://useshoppingcart.com/">use-shopping-cart</a>
     </h2>
     <CartProvider
       mode="client-only"

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,7 @@
   to = "https://useshoppingcart.com"
   status = 301
 
+  [[redirects]]
+  from = "https://use-shopping-cart.netlify.app/*"
+  to = "https://useshoppingcart.com/:splat"
+  status = 301

--- a/use-shopping-cart/README.md
+++ b/use-shopping-cart/README.md
@@ -38,7 +38,7 @@ At the root level of your application (or the highest point you'll be using Stri
 
 When loading up Stripe, don't forget to use your public Stripe API key with it. If you need help setting up your environment variables for this, [view a list of environment variable tutorials.](#Environment-Variable-Tutorials)
 
-#### [CheckoutSession mode](https://use-shopping-cart.netlify.app/usage/cartprovider#checkoutsession-mode)
+#### [CheckoutSession mode](https://useshoppingcart.com/usage/cartprovider#checkoutsession-mode)
 
 Creating a [CheckoutSession](https://stripe.com/docs/payments/checkout/one-time#create-checkout-session) server-side allows for a more flexible and powerful integration but requires a server component (e.g. a Netlify Function).
 
@@ -84,12 +84,11 @@ const products = [
 ]
 ```
 
-Additionally, you must verify the cartItems on the server-side before creating the CheckoutSession. For this you can use the [validateCartItems() helper](<https://use-shopping-cart.netlify.app/usage/validateCartItems()>).
+Additionally, you must verify the cartItems on the server-side before creating the CheckoutSession. For this you can use the [validateCartItems() helper](<https://useshoppingcart.com/usage/validateCartItems()>).
 
-#### [Client-only Checkout mode](https://use-shopping-cart.netlify.app/usage/cartprovider#client-only-checkout-mode)
+#### [Client-only Checkout mode](https://useshoppingcart.com/usage/cartprovider#client-only-checkout-mode)
 
-To operate a checkout page without any server component you need to enable client-only checkout mode and insert your
- product information in your Stripe Dashboard:
+To operate a checkout page without any server component you need to enable client-only checkout mode and insert your product information in your Stripe Dashboard:
 
 - [Enable client-only Checkout](https://stripe.com/docs/payments/checkout/client#enable-checkout)
 - [Create your products](https://stripe.com/docs/payments/checkout/client#create-products)
@@ -353,7 +352,7 @@ For a real-world robust example visit the [documentation for `setItemQuantity`](
 
 ## API
 
-You can [view the full API](https://use-shopping-cart.netlify.app/) on our documentation page.
+You can [view the full API](https://useshoppingcart.com/) on our documentation page.
 
 ### `<CartProvider>`
 
@@ -434,57 +433,57 @@ Returns an object with all the following properties and methods:
     <th>Return Type</th>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/addItem()"><code>addItem()</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/addItem()"><code>addItem()</code></a></td>
     <td>product: Object</td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/incrementItem()"><code>incrementItem()</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/incrementItem()"><code>incrementItem()</code></a></td>
     <td>sku: string</td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/decrementItem()"><code>decrementItem()</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/decrementItem()"><code>decrementItem()</code></a></td>
     <td>sku: string</td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/removeItem()"><code>removeItem()</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/removeItem()"><code>removeItem()</code></a></td>
     <td>sku: string</td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/setItemQuantity()"><code>setItemQuantity()</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/setItemQuantity()"><code>setItemQuantity()</code></a></td>
     <td>sku: string, quantity: number</td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/api#totalPrice"><code>totalPrice</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/api#totalPrice"><code>totalPrice</code></a></td>
     <td>N/A</td>
     <td>number</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/api#formattedTotalPrice"><code>formattedTotalPrice</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/api#formattedTotalPrice"><code>formattedTotalPrice</code></a></td>
     <td>N/A</td>
     <td>string</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/api#cartCount"><code>cartCount</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/api#cartCount"><code>cartCount</code></a></td>
     <td>number</td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/api#cartDetails"><code>cartDetails</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/api#cartDetails"><code>cartDetails</code></a></td>
     <td>Object of cart entries</td>
     <td>N/A</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/redirectToCheckout()"><code>redirectToCheckout()</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/redirectToCheckout()"><code>redirectToCheckout()</code></a></td>
     <td>sessionId?: string</td>
     <td>Error (if one occurrs)</td>
   </tr>
   <tr>
-    <td><a href="https://use-shopping-cart.netlify.app/usage/clearCart()"><code>clearCart()</code></a></td>
+    <td><a href="https://useshoppingcart.com/usage/clearCart()"><code>clearCart()</code></a></td>
     <td>N/A</td>
     <td>N/A</td>
   </tr>
@@ -560,8 +559,8 @@ yarn dev:docs
 ```
 
 ### Warning
-Please make all README edits to `/use-shopping-cart/README.md`. All edits to `/README.md` will be overwritten on
- commit by `/use-shopping-cart/README.md`. Consider `/README.md` read-only.
+
+Please make all README edits to `/use-shopping-cart/README.md`. All edits to `/README.md` will be overwritten on commit by `/use-shopping-cart/README.md`. Consider `/README.md` read-only.
 
 We created this hook with [create-react-hook](https://github.com/hermanya/create-react-hook).
 


### PR DESCRIPTION
⚠️ **NOTE:** It appears there have been commits to the [`README.md`](https://github.com/dayhaysoos/use-shopping-cart/commits/master/README.md) in the root of the project, which according to [the warning](https://github.com/dayhaysoos/use-shopping-cart/blob/632862b9372ca47c5d3edf3021548c7bdc936199/README.md#warning), those changes will be overwritten by my changes to `use-shopping-cart/README.md`

## Changes
* Update the Netlify redirect to use splats(catch all) as most of the doc links were resulting in a 404. I wasn't sure if the splat would also work for the root of the site, so I left the original redirect intact. 7e8ab5a
* Replace all occurrences of `https://use-shopping-cart.netlify.app` with the new url `https://useshoppingcart.com`. This will reduce the dependency on the redirect. 37a9a25 e6542b7 5e3fea6

📖  I would suggest adding [the warning](https://github.com/dayhaysoos/use-shopping-cart/blob/632862b9372ca47c5d3edf3021548c7bdc936199/README.md#warning) about which README to edit to the [CONTRIBUTING.md](https://github.com/dayhaysoos/use-shopping-cart/blob/482207886985c026a81193876e3a391691ffa44e/use-shopping-cart/CONTRIBUTING.md) file. As mentioned above, the read only README was committed to, and I would have committed to it as well had I not spotted it when looking for outdated links. I didn't make this change as I felt it was out of scope of this PR.