### PR TITLE
Nick/create session v2

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -22,7 +22,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "typeface-bungee": "^0.0.72",
-    "use-shopping-cart": "^2.1.0"
+    "use-shopping-cart": "^2.3.0-beta.0"
   },
   "devDependencies": {},
   "keywords": [

--- a/documentation/src/components/load-cart.js
+++ b/documentation/src/components/load-cart.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import { useShoppingCart } from 'use-shopping-cart'
+
+export function LoadCart() {
+  const { loadCart } = useShoppingCart()
+
+  const cartData = {
+    some_product: {
+      name: 'Some Product',
+      sku: 'some_product',
+      price: 400,
+      currency: 'USD',
+      id: 'some_product',
+      quantity: 5,
+      value: 750,
+      formattedValue: '$7.50'
+    }
+  }
+
+  return (
+    <article
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '50%'
+      }}
+    >
+      <section
+        style={{
+          display: 'flex',
+          justifyContent: 'space-evenly',
+          width: '100%',
+          flexDirection: 'column'
+        }}
+      >
+        <pre
+          style={{
+            backgroundColor: 'lightgray',
+            marginBottom: 10,
+            fontSize: 12,
+            padding: 10,
+            height: 200,
+            overflow: 'scroll'
+          }}
+        >
+          {JSON.stringify(cartData, null, 2)}
+        </pre>
+        <button
+          onClick={() => loadCart(cartData)}
+          aria-label={`Add cart data to your cart`}
+          style={{ height: 50, width: 100, marginBottom: 30 }}
+        >
+          Load Cart data to Cart
+        </button>
+        <button
+          onClick={() => loadCart(cartData, false)}
+          aria-label={`Add cart data to your cart`}
+          style={{ height: 50, width: 100, marginBottom: 30 }}
+        >
+          Replace Cart data
+        </button>
+      </section>
+    </article>
+  )
+}
+
+export default LoadCart

--- a/documentation/src/config/sidebar.yml
+++ b/documentation/src/config/sidebar.yml
@@ -1,40 +1,44 @@
 # Sidebar navigation
 
-- label: 'Introduction'
-  link: '/'
-- label: 'GitHub'
-  link: 'https://github.com/dayhaysoos/use-shopping-cart'
-- label: 'Discord'
-  link: '/discord'
-- label: 'Getting started'
-  link: '/getting-started'
+- label: "Introduction"
+  link: "/"
+- label: "GitHub"
+  link: "https://github.com/dayhaysoos/use-shopping-cart"
+- label: "Discord"
+  link: "/discord"
+- label: "Getting started"
+  link: "/getting-started"
 - label: Usage
   items:
-    - label: 'CartProvider'
-      link: '/usage/cartprovider'
-    - label: 'addItem()'
-      link: '/usage/addItem()'
-    - label: 'incrementItem()'
-      link: '/usage/incrementItem()'
-    - label: 'decrementItem()'
-      link: '/usage/decrementItem()'
-    - label: 'setItemQuantity()'
-      link: '/usage/setItemQuantity()'
-    - label: 'removeItem()'
-      link: '/usage/removeItem()'
-    - label: 'clearCart()'
-      link: '/usage/clearCart()'
-    - label: 'redirectToCheckout()'
-      link: '/usage/redirectToCheckout()'
-    - label: 'checkoutSingleItem()'
-      link: '/usage/checkoutSingleItem()'
-    - label: 'validateCartItems()'
-      link: '/usage/validateCartItems()'
-    - label: 'API'
-      link: '/usage/api'
-- label: 'Contributors'
-  link: '/contributors'
-- label: 'Util'
+    - label: "CartProvider"
+      link: "/usage/cartprovider"
+    - label: "addItem()"
+      link: "/usage/addItem()"
+    - label: "incrementItem()"
+      link: "/usage/incrementItem()"
+    - label: "decrementItem()"
+      link: "/usage/decrementItem()"
+    - label: "setItemQuantity()"
+      link: "/usage/setItemQuantity()"
+    - label: "removeItem()"
+      link: "/usage/removeItem()"
+    - label: "clearCart()"
+      link: "/usage/clearCart()"
+    - label: "redirectToCheckout()"
+      link: "/usage/redirectToCheckout()"
+    - label: "checkoutSingleItem()"
+      link: "/usage/checkoutSingleItem()"
+    - label: "validateCartItems()"
+      link: "/usage/validateCartItems()"
+    - label: "loadCart()"
+      link: "/usage/loadCart()"
+    - label: formatLineItems()
+      link: "/usage/formatLineItems()"
+    - label: "API"
+      link: "/usage/api"
+- label: "Contributors"
+  link: "/contributors"
+- label: "Util"
   items:
     - label: formatCurrencyString()
-      link: '/util/formatCurrencyString()'
+      link: "/util/formatCurrencyString()"

--- a/documentation/src/docs/getting-started.mdx
+++ b/documentation/src/docs/getting-started.mdx
@@ -42,9 +42,14 @@ ReactDOM.render(
 )
 ```
 
-### Using the hook
+## Using the hook
 
 The hook `useShoppingCart()` provides several utilities and pieces of data for you to use in your application. The examples below won't cover every part of the `useShoppingCart()` API but you can [look at the API](#API) below.
+
+### Products Created on Stripe's Dashboard
+
+This is for products you created on the Stripe Dashboard. Stripe provides you with a Price ID String. You don't need a server(less)
+set up to use this library this way unless you want more control over how the payments are handled.
 
 ```jsx
 import { useShoppingCart } from 'use-shopping-cart'
@@ -54,14 +59,14 @@ import { CartItems } from './CartItems'
 const productData = [
   {
     name: 'Bananas',
-    sku: 'sku_GBJ2Ep8246qeeT',
+    price_id: 'price_GBJ2Ep8246qeeT',
     price: 400,
     image: 'https://www.fillmurray.com/300/300',
     currency: 'USD'
   },
   {
     name: 'Tangerines',
-    sku: 'sku_GBJ2WWfMaGNC2Z',
+    price_id: 'price_GBJ2WWfMaGNC2Z',
     price: 100,
     image: 'https://www.fillmurray.com/300/300',
     currency: 'USD'
@@ -91,20 +96,57 @@ export function App() {
 }
 ```
 
-Once you have successfully installed `stripe`, `use-shopping-cart`, and wrapped your root component with `<CartProvider>`, you are ready to go! 🚀
+### Server(less) implementation
 
-### ⚠️ HEADS UP!
+If you're data source isn't coming from Stripe's dashboard, you can still make products and make payments happen from them.
 
-You may not be able to see the SKUs section in your products on Stripe but a **Prices** section instead. If that's the case, you can use the price ID (i.e. `price_abcd1234`) as the `sku` property in your inventory.
+You're product data should look like this:
 
-```js
+```jsx
 const productData = [
   {
     name: 'Bananas',
-    sku: 'price_GBJ2Ep8246qeeT', // 👈
+    id: 'some_unique_id_1',
     price: 400,
     image: 'https://www.fillmurray.com/300/300',
     currency: 'USD'
+    product_data: {
+      metadata: {
+        type: 'fruit'
+      }
+    },
+    price_data: {
+      recurring: {
+        interval: 'week'
+      }
+    }
+  },
+  {
+    name: 'Tangerines',
+    id: 'some_unique_id_2',
+    price: 100,
+    image: 'https://www.fillmurray.com/300/300',
+    currency: 'USD',
+    product_data: {
+      metadata: {
+        type: 'fruit'
+      }
+    },
+    price_data: {
+      recurring: {
+        interval: 'week'
+      }
+    }
   }
 ]
 ```
+
+_NOTE_: `price_data` and `product_data` are not required for use-shopping-cart to work, but they are required for creating Sessions with Stripe.
+
+This library manages `price_data` and `product_data` for you, but if you need to pass extra data to your Sessions, you can add them directly to your
+product objects.
+
+Also keep in mind that `product_data` is a child of `price_data` when being sent to Stripe, but you don't need to nest for use-shopping-cart. Learn more about
+creating Sessions here: https://stripe.com/docs/api/checkout/sessions/create
+
+Once you have successfully installed `stripe`, `use-shopping-cart`, and wrapped your root component with `<CartProvider>`, you are ready to go! 🚀

--- a/documentation/src/docs/usage/addItem().mdx
+++ b/documentation/src/docs/usage/addItem().mdx
@@ -7,14 +7,19 @@ import AddItem from 'components/add-item'
 
 To add a product to the cart, use `useShoppingCart()`'s `addItem(product)` method. It takes in your product object which must be in the following shape:
 
-| Key           | Value (type)                                                    | Required                    |
-| :------------ | :-------------------------------------------------------------- | :-------------------------- |
-| `name`        | Name of the product to be shown on the Checkout page (string)   | Yes in CheckoutSession mode |
-| `description` | description to be shown on the Stripe Checkout page (string)    | No                          |
-| `sku`         | A unique identifier (stock keeping unit) for this item (string) | Yes                         |
-| `price`       | Price in smallest currency unit (number)                        | Yes                         |
-| `currency`    | ISO currency code (string)                                      | Yes                         |
-| `image`       | Image to be shown on the Stripe Checkout page (string)          | No                          |
+| Key            | Value (type)                                                  | Required                    |
+| :------------- | :------------------------------------------------------------ | :-------------------------- |
+| `name`         | Name of the product to be shown on the Checkout page (string) | Yes in CheckoutSession mode |
+| `description`  | description to be shown on the Stripe Checkout page (string)  | No                          |
+| `id `          | A unique identifier for this item (string)                    | Yes                         |
+| `price`        | Price in smallest currency unit (number)                      | Yes                         |
+| `currency`     | ISO currency code (string)                                    | Yes                         |
+| `image`        | Image to be shown on the Stripe Checkout page (string)        | No                          |
+| `price_id`     | Price id provided by Stripe                                   | No                          |
+| `sku_id `      | SKU id provided by Stripe (Supports Deprecated API)           | No                          |
+| `sku`          | A unique identifier for this item (string)                    | No (Interchangable with id) |
+| `price_data`   | Optional params for Price API for Serverless integrations     | Required for Session id     |
+| `product_data` | Optional params for Price API for Serverless integrations     | Required for Session id     |
 
 ```js
 const products = [
@@ -28,6 +33,12 @@ const products = [
   }
 ]
 ```
+
+### HEADS UP
+
+When this library was made, it was done with Stripe's SKU API in mind. SKU is depreceated now in favor
+of the Price API. This is why `sku` and `id` are interchangable. You can use `sku` if you want, but it's preferred
+that you use `id` instead.
 
 You can add an optional quantity param, to add by that number. `addItem(product, 10)` for example would add by 10.
 

--- a/documentation/src/docs/usage/addItem().mdx
+++ b/documentation/src/docs/usage/addItem().mdx
@@ -26,7 +26,7 @@ const products = [
   {
     name: 'Bananas',
     description: 'Yummy yellow fruit',
-    sku: 'sku_banana001',
+    id: 'id_banana001',
     price: 400,
     currency: 'USD',
     image: 'https://my-image.com/banana.jpg'
@@ -46,7 +46,7 @@ You can add an optional quantity param, to add by that number. `addItem(product,
   <AddItem
     product={{
       name: 'Bananas',
-      sku: 'sku_GBJ2Ep8246qeeT',
+      id: 'id_GBJ2Ep8246qeeT',
       price: 400,
       image:
         'https://images.unsplash.com/photo-1574226516831-e1dff420e562?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1050&q=80',

--- a/documentation/src/docs/usage/formatLineItems().mdx
+++ b/documentation/src/docs/usage/formatLineItems().mdx
@@ -1,0 +1,11 @@
+---
+title: formatLineItems()
+---
+
+`formatLineItems(cartDetails)` Is a function that helps with creating Session IDs server side
+for products that have been created on the Stripe dashboard. It's preferred to use this with the
+Price API.
+
+
+It's important that your product data has a `price_id` key that provides the given Price ID you get
+from Stripe's dashboard.

--- a/documentation/src/docs/usage/loadCart().mdx
+++ b/documentation/src/docs/usage/loadCart().mdx
@@ -18,73 +18,23 @@ import LoadCart from 'components/load-cart'
 </CartDisplayWrapper>
 
 ```jsx
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useShoppingCart } from 'use-shopping-cart'
 
 export function LoadCart({ product }) {
   const { loadCart } = useShoppingCart()
 
-  const cartData = {
-    some_product: {
-      name: 'Some Product',
-      sku: 'some_product',
-      price: 400,
-      currency: 'USD',
-      id: 'some_product',
-      quantity: 5,
-      value: 750,
-      formattedValue: '$7.50'
-    }
-  }
+  // Make an API request to your backend with useEffect()
+  useEffect(async () => {
+    const cartData = await getData()
 
-  return (
-    <article
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '50%'
-      }}
-    >
-      <section
-        style={{
-          display: 'flex',
-          justifyContent: 'space-evenly',
-          width: '100%',
-          flexDirection: 'column'
-        }}
-      >
-        <pre
-          style={{
-            backgroundColor: 'lightgray',
-            marginBottom: 10,
-            fontSize: 12,
-            padding: 10,
-            height: 200,
-            overflow: 'scroll'
-          }}
-        >
-          {JSON.stringify(cartData, null, 2)}
-        </pre>
-        <button
-          onClick={() => loadCart(cartData)}
-          aria-label={`Add cart data to your cart`}
-          style={{ height: 50, width: 100, marginBottom: 30 }}
-        >
-          Load Cart data to Cart
-        </button>
-        <button
-          onClick={() => loadCart(cartData, false)}
-          aria-label={`Add cart data to your cart`}
-          style={{ height: 50, width: 100, marginBottom: 30 }}
-        >
-          Replace Cart data
-        </button>
-      </section>
-    </article>
-  )
+    loadCart(cartData)
+  }, [])
+
+  return <YourComponent />
 }
 
 export default LoadCart
 ```
+
+The above example is the ideal use-case for `loadCart()`

--- a/documentation/src/docs/usage/loadCart().mdx
+++ b/documentation/src/docs/usage/loadCart().mdx
@@ -1,0 +1,90 @@
+---
+title: loadCart()
+---
+
+`loadCart(cartData, shouldMerge = true)` allows you to load a previously created cart to the current cart.
+
+import CartDisplayWrapper from 'components/cart-display-wrapper'
+import LoadCart from 'components/load-cart'
+
+## Params
+
+`cartData` - Previously created cart details data
+
+`shouldMerge` - If `true`, merges different cartDetails data together. If false, replaces cart with `cartData`
+
+<CartDisplayWrapper>
+  <LoadCart />
+</CartDisplayWrapper>
+
+```jsx
+import React from 'react'
+import { useShoppingCart } from 'use-shopping-cart'
+
+export function LoadCart({ product }) {
+  const { loadCart } = useShoppingCart()
+
+  const cartData = {
+    some_product: {
+      name: 'Some Product',
+      sku: 'some_product',
+      price: 400,
+      currency: 'USD',
+      id: 'some_product',
+      quantity: 5,
+      value: 750,
+      formattedValue: '$7.50'
+    }
+  }
+
+  return (
+    <article
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: '50%'
+      }}
+    >
+      <section
+        style={{
+          display: 'flex',
+          justifyContent: 'space-evenly',
+          width: '100%',
+          flexDirection: 'column'
+        }}
+      >
+        <pre
+          style={{
+            backgroundColor: 'lightgray',
+            marginBottom: 10,
+            fontSize: 12,
+            padding: 10,
+            height: 200,
+            overflow: 'scroll'
+          }}
+        >
+          {JSON.stringify(cartData, null, 2)}
+        </pre>
+        <button
+          onClick={() => loadCart(cartData)}
+          aria-label={`Add cart data to your cart`}
+          style={{ height: 50, width: 100, marginBottom: 30 }}
+        >
+          Load Cart data to Cart
+        </button>
+        <button
+          onClick={() => loadCart(cartData, false)}
+          aria-label={`Add cart data to your cart`}
+          style={{ height: 50, width: 100, marginBottom: 30 }}
+        >
+          Replace Cart data
+        </button>
+      </section>
+    </article>
+  )
+}
+
+export default LoadCart
+```

--- a/examples/cra/functions/create-session.js
+++ b/examples/cra/functions/create-session.js
@@ -31,7 +31,7 @@ exports.handler = async (event) => {
       shipping_address_collection: {
         allowed_countries: ['US', 'CA']
       },
-
+      mode: 'payment',
       /*
        * This env var is set by Netlify and inserts the live site URL. If you want
        * to use a different URL, you can hard-code it here or check out the

--- a/examples/cra/functions/data/price-products.json
+++ b/examples/cra/functions/data/price-products.json
@@ -1,0 +1,9 @@
+[
+    {
+    "name": "Sunglasses",
+    "price_id": "price_1GwzfVCNNrtKkPVCh2MVxRkO",
+    "price": 100,
+    "image": "https://files.stripe.com/links/fl_test_FR8EZTS7UDXE0uljMfT7hwmH",
+    "currency": "USD"
+  }
+]

--- a/examples/cra/functions/data/products.json
+++ b/examples/cra/functions/data/products.json
@@ -1,16 +1,16 @@
 [
   {
     "name": "Bananas",
-    "sku": "sku_GBJ2Ep8246qeeT",
+    "sku": "test1",
     "price": 400,
-    "image": "https: //www.fillmurray.com/300/300",
+    "image": "https://i.imgur.com/AUJQtJC.jpg",
     "currency": "USD"
   },
   {
     "name": "Tangerines",
-    "sku": "sku_GBJ2WWfMaGNC2Z",
+    "sku": "test2",
     "price": 100,
-    "image": "https: //www.fillmurray.com/300/300",
+    "image": "https://i.imgur.com/4rVhatT.jpg",
     "currency": "USD"
   }
 ]

--- a/examples/cra/functions/prices-create-session.js
+++ b/examples/cra/functions/prices-create-session.js
@@ -1,0 +1,54 @@
+/*
+ * This function creates a Stripe Checkout session and returns the session ID
+ * for use with Stripe.js (specifically the redirectToCheckout method).
+ *
+ * @see https://stripe.com/docs/payments/checkout/one-time
+ */
+
+const stripe = require('stripe')(process.env.REACT_APP_STRIPE_API_SECRET)
+
+const formatLineItems = require('use-shopping-cart/src/serverUtil')
+  .formatLineItems
+
+/*
+ * Product data can be loaded from anywhere. In this case, we’re loading it from
+ * a local JSON file, but this could also come from an async call to your
+ * inventory management service, a database query, or some other API call.
+ *
+ * The important thing is that the product info is loaded from somewhere trusted
+ * so you know the pricing information is accurate.
+ */
+
+exports.handler = async (event) => {
+  try {
+    const productJSON = JSON.parse(event.body)
+
+    const line_items = formatLineItems(productJSON)
+    console.log('line-items', line_items)
+
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      billing_address_collection: 'auto',
+      shipping_address_collection: {
+        allowed_countries: ['US', 'CA']
+      },
+      mode: 'payment',
+      /*
+       * This env var is set by Netlify and inserts the live site URL. If you want
+       * to use a different URL, you can hard-code it here or check out the
+       * other environment variables Netlify exposes:
+       * https://docs.netlify.com/configure-builds/environment-variables/
+       */
+      success_url: `${process.env.URL}/success.html`,
+      cancel_url: process.env.URL,
+      line_items
+    })
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ sessionId: session.id })
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}

--- a/examples/cra/functions/prices-create-session.js
+++ b/examples/cra/functions/prices-create-session.js
@@ -24,7 +24,6 @@ exports.handler = async (event) => {
     const productJSON = JSON.parse(event.body)
 
     const line_items = formatLineItems(productJSON)
-    console.log('line-items', line_items)
 
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],

--- a/examples/cra/src/App.js
+++ b/examples/cra/src/App.js
@@ -7,16 +7,16 @@ import CartDisplay from './components/cart-display'
 const fakeData = [
   {
     name: 'Bananas',
-    sku: 'sku_GBJ2Ep8246qeeT',
+    sku: 'test1',
     price: 400,
-    image: 'https://www.fillmurray.com/300/300',
+    image: 'https://i.imgur.com/AUJQtJC.jpg',
     currency: 'USD'
   },
   {
     name: 'Tangerines',
-    sku: 'sku_GBJ2WWfMaGNC2Z',
+    sku: 'test2',
     price: 100,
-    image: 'https://www.fillmurray.com/300/300',
+    image: 'https://i.imgur.com/4rVhatT.jpg',
     currency: 'USD'
   }
 ]

--- a/examples/cra/src/App.js
+++ b/examples/cra/src/App.js
@@ -1,7 +1,8 @@
 /**@jsx jsx */
 import { jsx } from 'theme-ui'
-import { Flex } from 'theme-ui'
+import { Flex, Box } from 'theme-ui'
 import Products from './components/products'
+import PriceProducts from './components/price-products'
 import CartDisplay from './components/cart-display'
 
 const fakeData = [
@@ -25,10 +26,25 @@ const fakeData = [
   }
 ]
 
+const priceProducts = [
+  {
+    name: 'Sunglasses',
+    price_id: 'price_1GwzfVCNNrtKkPVCh2MVxRkO',
+    price: 100,
+    image: 'https://files.stripe.com/links/fl_test_FR8EZTS7UDXE0uljMfT7hwmH',
+    currency: 'USD'
+  }
+]
+
 const App = () => {
   return (
     <Flex sx={{ justifyContent: 'space-evenly' }}>
-      <Products products={fakeData} />
+      <Box>
+        <h2>Products not created in the Stripe Dashboard</h2>
+        <Products products={fakeData} />
+        <h2>Products made on Stripe Dashboard using Price API</h2>
+        <PriceProducts products={priceProducts} />
+      </Box>
       <CartDisplay />
     </Flex>
   )

--- a/examples/cra/src/App.js
+++ b/examples/cra/src/App.js
@@ -8,6 +8,8 @@ const fakeData = [
   {
     name: 'Bananas',
     sku: 'test1',
+    // price_id: 'price_id_test1',
+    // sku_id: 'sku_id_test1',
     price: 400,
     image: 'https://i.imgur.com/AUJQtJC.jpg',
     currency: 'USD'
@@ -15,6 +17,8 @@ const fakeData = [
   {
     name: 'Tangerines',
     sku: 'test2',
+    // price_id: 'price_id_test2',
+    // sku_id: 'sku_id_test2',
     price: 100,
     image: 'https://i.imgur.com/4rVhatT.jpg',
     currency: 'USD'

--- a/examples/cra/src/components/price-product.js
+++ b/examples/cra/src/components/price-product.js
@@ -1,0 +1,50 @@
+/**@jsx jsx */
+import { jsx, Box, Image, Button, Flex } from 'theme-ui'
+import { useShoppingCart, formatCurrencyString } from 'use-shopping-cart'
+
+// for products that are made in the stripe dashboard
+
+const PriceProduct = (product) => {
+  const { addItem, redirectToCheckout } = useShoppingCart()
+  const { name, price, image, currency } = product
+
+  async function handleCheckout() {
+    const response = await fetch('/.netlify/functions/prices-create-session', {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ [product.price_id]: { ...product, quantity: 1 } })
+    })
+      .then((res) => {
+        return res.json()
+      })
+      .catch((error) => console.log(error))
+
+    redirectToCheckout({ sessionId: response.sessionId })
+  }
+
+  return (
+    <Flex
+      sx={{
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center'
+      }}
+    >
+      <Image src={image} />
+      <Box>
+        <p>{name}</p>
+        <p>{formatCurrencyString({ value: price, currency })}</p>
+      </Box>
+      <Button onClick={() => addItem(product)} backgroundColor={'black'}>
+        Add To Cart
+      </Button>
+      <Button onClick={handleCheckout} backgroundColor={'black'}>
+        Buy Now
+      </Button>
+    </Flex>
+  )
+}
+
+export default PriceProduct

--- a/examples/cra/src/components/price-products.js
+++ b/examples/cra/src/components/price-products.js
@@ -1,0 +1,17 @@
+/**@jsx jsx */
+import { jsx, Grid } from 'theme-ui'
+import PriceProduct from './price-product'
+
+// products created from the Stripe dashboard that have price ids
+
+const PriceProducts = ({ products }) => {
+  return (
+    <Grid columns={2}>
+      {products.map((product) => (
+        <PriceProduct key={product.price_id} {...product} />
+      ))}
+    </Grid>
+  )
+}
+
+export default PriceProducts

--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -74,6 +74,7 @@
     "rollup": "^2.3.3"
   },
   "dependencies": {
-    "react-storage-hooks": "^4.0.0"
+    "react-storage-hooks": "^4.0.0",
+    "uuid": "^8.3.1"
   }
 }

--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-shopping-cart",
-  "version": "2.2.0",
+  "version": "2.3.0-beta.0",
   "description": "Shopping cart state and logic for Stripe",
   "author": "dayhaysoos",
   "license": "MIT",

--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-shopping-cart",
-  "version": "2.3.0-beta.0",
+  "version": "2.3.0",
   "description": "Shopping cart state and logic for Stripe",
   "author": "dayhaysoos",
   "license": "MIT",

--- a/use-shopping-cart/src/index.js
+++ b/use-shopping-cart/src/index.js
@@ -108,17 +108,16 @@ export const useShoppingCart = () => {
 
   const addItem = (product, count = 1) =>
     dispatch({ type: 'add-item-to-cart', product, count })
-  const removeItem = (sku) => dispatch({ type: 'remove-item-from-cart', sku })
-  const setItemQuantity = (sku, quantity) =>
-    dispatch({ type: 'set-item-quantity', sku, quantity })
-  const incrementItem = (sku, count = 1) =>
-    dispatch({ type: 'increment-item', sku, count })
-  const decrementItem = (sku, count = 1) =>
-    dispatch({ type: 'decrement-item', sku, count })
+  const removeItem = (id) => dispatch({ type: 'remove-item-from-cart', id })
+  const setItemQuantity = (id, quantity) =>
+    dispatch({ type: 'set-item-quantity', id, quantity })
+  const incrementItem = (id, count = 1) =>
+    dispatch({ type: 'increment-item', id, count })
+  const decrementItem = (id, count = 1) =>
+    dispatch({ type: 'decrement-item', id, count })
   const clearCart = () => dispatch({ type: 'clear-cart' })
 
-  const storeLastClicked = (sku) =>
-    dispatch({ type: 'store-last-clicked', sku })
+  const storeLastClicked = (id) => dispatch({ type: 'store-last-clicked', id })
   const handleCartClick = () => dispatch({ type: 'cart-click' })
   const handleCartHover = () => dispatch({ type: 'cart-hover' })
   const handleCloseCart = () => dispatch({ type: 'close-cart' })

--- a/use-shopping-cart/src/index.test.js
+++ b/use-shopping-cart/src/index.test.js
@@ -24,7 +24,6 @@ const createWrapper = (overrides = {}) => ({ children }) => (
 let counter = 0
 function mockProduct(overrides) {
   return {
-    sku: `sku_abc${counter++}`,
     id: `sku_abc${counter++}`,
     name: 'blah bleh bloo',
     price: Math.floor(Math.random() * 1000 + 1),
@@ -564,7 +563,6 @@ function mockCartDetails(overrides) {
   return {
     [`sku_abc${counter}`]: {
       sku: `sku_abc${counter++}`,
-      id: `sku_abc${counter++}`,
       name: 'Bananas',
       image: 'https://blah.com/banana.avif',
       price: 400,
@@ -576,7 +574,6 @@ function mockCartDetails(overrides) {
     },
     [`sku_efg${counter}`]: {
       sku: `sku_efg${counter++}`,
-      id: `sku_efg${counter++}`,
       name: 'Oranges',
       image: 'https://blah.com/orange.avif',
       currency: 'USD',
@@ -601,7 +598,19 @@ describe('loadCart()', () => {
       cart.current.loadCart(cartDetails, false)
     })
 
-    expect(cart.current.cartDetails).toEqual(cartDetails)
+    const itemId1 = Object.keys(cartDetails)[0]
+    const itemId2 = Object.keys(cartDetails)[1]
+
+    expect(cart.current.cartDetails).toEqual({
+      [itemId1]: {
+        ...cartDetails[itemId1],
+        id: itemId1
+      },
+      [itemId2]: {
+        ...cartDetails[itemId2],
+        id: itemId2
+      }
+    })
     expect(cart.current.totalPrice).toEqual(1800)
     expect(cart.current.cartCount).toEqual(6)
   })
@@ -619,10 +628,20 @@ describe('loadCart()', () => {
       cart.current.loadCart(cartDetails)
     })
 
+    const itemId1 = Object.keys(cartDetails)[0]
+    const itemId2 = Object.keys(cartDetails)[1]
+
     const entry = cart.current.cartDetails[product.id]
     expect(cart.current.cartDetails).toEqual({
       [entry.id]: entry,
-      ...cartDetails
+      [itemId1]: {
+        ...cartDetails[itemId1],
+        id: itemId1
+      },
+      [itemId2]: {
+        ...cartDetails[itemId2],
+        id: itemId2
+      }
     })
     expect(cart.current.totalPrice).toEqual(2200)
     expect(cart.current.cartCount).toEqual(8)

--- a/use-shopping-cart/src/index.test.js
+++ b/use-shopping-cart/src/index.test.js
@@ -25,6 +25,7 @@ let counter = 0
 function mockProduct(overrides) {
   return {
     sku: `sku_abc${counter++}`,
+    id: `sku_abc${counter++}`,
     name: 'blah bleh bloo',
     price: Math.floor(Math.random() * 1000 + 1),
     image: 'https://blah.com/bleh',
@@ -563,6 +564,7 @@ function mockCartDetails(overrides) {
   return {
     [`sku_abc${counter}`]: {
       sku: `sku_abc${counter++}`,
+      id: `sku_abc${counter++}`,
       name: 'Bananas',
       image: 'https://blah.com/banana.avif',
       price: 400,
@@ -574,6 +576,7 @@ function mockCartDetails(overrides) {
     },
     [`sku_efg${counter}`]: {
       sku: `sku_efg${counter++}`,
+      id: `sku_efg${counter++}`,
       name: 'Oranges',
       image: 'https://blah.com/orange.avif',
       currency: 'USD',

--- a/use-shopping-cart/src/index.test.js
+++ b/use-shopping-cart/src/index.test.js
@@ -56,9 +56,9 @@ describe('useShoppingCart()', () => {
   it('storeLastClicked() updates lastClicked', () => {
     const product = mockProduct()
     act(() => {
-      cart.current.storeLastClicked(product.sku)
+      cart.current.storeLastClicked(product.id)
     })
-    expect(cart.current.lastClicked).toBe(product.sku)
+    expect(cart.current.lastClicked).toBe(product.id)
   })
 
   describe('shouldDisplayCart', () => {
@@ -97,8 +97,8 @@ describe('useShoppingCart()', () => {
         cart.current.addItem(product)
       })
 
-      expect(cart.current.cartDetails).toHaveProperty(product.sku)
-      const entry = cart.current.cartDetails[product.sku]
+      expect(cart.current.cartDetails).toHaveProperty(product.id)
+      const entry = cart.current.cartDetails[product.id]
 
       expect(entry.quantity).toBe(1)
       expect(entry.value).toBe(product.price)
@@ -118,8 +118,8 @@ describe('useShoppingCart()', () => {
           cart.current.addItem(product, count)
         })
 
-        expect(cart.current.cartDetails).toHaveProperty(product.sku)
-        const entry = cart.current.cartDetails[product.sku]
+        expect(cart.current.cartDetails).toHaveProperty(product.id)
+        const entry = cart.current.cartDetails[product.id]
 
         expect(entry.quantity).toBe(count)
         expect(entry.value).toBe(product.price * count)
@@ -138,14 +138,14 @@ describe('useShoppingCart()', () => {
         cart.current.addItem(product2)
       })
 
-      expect(cart.current.cartDetails).toHaveProperty(product1.sku)
-      const entry1 = cart.current.cartDetails[product1.sku]
+      expect(cart.current.cartDetails).toHaveProperty(product1.id)
+      const entry1 = cart.current.cartDetails[product1.id]
 
       expect(entry1.quantity).toBe(1)
       expect(entry1.value).toBe(product1.price)
 
-      expect(cart.current.cartDetails).toHaveProperty(product2.sku)
-      const entry2 = cart.current.cartDetails[product2.sku]
+      expect(cart.current.cartDetails).toHaveProperty(product2.id)
+      const entry2 = cart.current.cartDetails[product2.id]
 
       expect(entry2.quantity).toBe(1)
       expect(entry2.value).toBe(product2.price)
@@ -162,8 +162,8 @@ describe('useShoppingCart()', () => {
         cart.current.addItem(product)
       })
 
-      expect(cart.current.cartDetails).toHaveProperty(product.sku)
-      const entry = cart.current.cartDetails[product.sku]
+      expect(cart.current.cartDetails).toHaveProperty(product.id)
+      const entry = cart.current.cartDetails[product.id]
 
       expect(entry.quantity).toBe(2)
       expect(entry.value).toBe(650)
@@ -180,10 +180,10 @@ describe('useShoppingCart()', () => {
 
       act(() => {
         cart.current.addItem(product)
-        cart.current.removeItem(product.sku)
+        cart.current.removeItem(product.id)
       })
 
-      expect(cart.current.cartDetails).not.toHaveProperty(product.sku)
+      expect(cart.current.cartDetails).not.toHaveProperty(product.id)
     })
 
     it('should remove correct item', () => {
@@ -193,11 +193,11 @@ describe('useShoppingCart()', () => {
       act(() => {
         cart.current.addItem(product1, 2)
         cart.current.addItem(product2, 4)
-        cart.current.removeItem(product1.sku)
+        cart.current.removeItem(product1.id)
       })
 
-      expect(cart.current.cartDetails).not.toHaveProperty(product1.sku)
-      expect(cart.current.cartDetails).toHaveProperty(product2.sku)
+      expect(cart.current.cartDetails).not.toHaveProperty(product1.id)
+      expect(cart.current.cartDetails).toHaveProperty(product2.id)
     })
   })
 
@@ -207,11 +207,11 @@ describe('useShoppingCart()', () => {
 
       act(() => {
         cart.current.addItem(product)
-        cart.current.incrementItem(product.sku)
+        cart.current.incrementItem(product.id)
       })
 
-      expect(cart.current.cartDetails).toHaveProperty(product.sku)
-      const entry = cart.current.cartDetails[product.sku]
+      expect(cart.current.cartDetails).toHaveProperty(product.id)
+      const entry = cart.current.cartDetails[product.id]
 
       expect(entry.quantity).toBe(2)
       expect(entry.value).toBe(product.price * 2)
@@ -225,11 +225,11 @@ describe('useShoppingCart()', () => {
 
         act(() => {
           cart.current.addItem(product)
-          cart.current.incrementItem(product.sku, count)
+          cart.current.incrementItem(product.id, count)
         })
 
-        expect(cart.current.cartDetails).toHaveProperty(product.sku)
-        const entry = cart.current.cartDetails[product.sku]
+        expect(cart.current.cartDetails).toHaveProperty(product.id)
+        const entry = cart.current.cartDetails[product.id]
 
         const expectedQuantity = count + 1
         expect(entry.quantity).toBe(expectedQuantity)
@@ -247,11 +247,11 @@ describe('useShoppingCart()', () => {
 
       act(() => {
         cart.current.addItem(product, 3)
-        cart.current.decrementItem(product.sku)
+        cart.current.decrementItem(product.id)
       })
 
-      expect(cart.current.cartDetails).toHaveProperty(product.sku)
-      const entry = cart.current.cartDetails[product.sku]
+      expect(cart.current.cartDetails).toHaveProperty(product.id)
+      const entry = cart.current.cartDetails[product.id]
 
       expect(entry.quantity).toBe(2)
       expect(entry.value).toBe(512)
@@ -273,11 +273,11 @@ describe('useShoppingCart()', () => {
         act(() => {
           // add a random number of product to the cart
           cart.current.addItem(product, randomNumberAboveCount)
-          cart.current.decrementItem(product.sku, count)
+          cart.current.decrementItem(product.id, count)
         })
 
-        expect(cart.current.cartDetails).toHaveProperty(product.sku)
-        const entry = cart.current.cartDetails[product.sku]
+        expect(cart.current.cartDetails).toHaveProperty(product.id)
+        const entry = cart.current.cartDetails[product.id]
 
         expect(entry.quantity).toBe(endQuantity)
         expect(entry.value).toBe(endQuantity * product.price)
@@ -292,10 +292,10 @@ describe('useShoppingCart()', () => {
 
       act(() => {
         cart.current.addItem(product)
-        cart.current.decrementItem(product.sku)
+        cart.current.decrementItem(product.id)
       })
 
-      expect(cart.current.cartDetails).not.toHaveProperty(product.sku)
+      expect(cart.current.cartDetails).not.toHaveProperty(product.id)
       expect(cart.current.totalPrice).toBe(0)
       expect(cart.current.cartCount).toBe(0)
     })
@@ -305,10 +305,10 @@ describe('useShoppingCart()', () => {
 
       act(() => {
         cart.current.addItem(product)
-        cart.current.decrementItem(product.sku, 5)
+        cart.current.decrementItem(product.id, 5)
       })
 
-      expect(cart.current.cartDetails).not.toHaveProperty(product.sku)
+      expect(cart.current.cartDetails).not.toHaveProperty(product.id)
       expect(cart.current.totalPrice).toBe(0)
       expect(cart.current.cartCount).toBe(0)
     })
@@ -320,11 +320,11 @@ describe('useShoppingCart()', () => {
       act(() => {
         cart.current.addItem(product1, 2)
         cart.current.addItem(product2, 4)
-        cart.current.decrementItem(product2.sku)
+        cart.current.decrementItem(product2.id)
       })
 
-      expect(cart.current.cartDetails[product1.sku].quantity).toBe(2)
-      expect(cart.current.cartDetails[product2.sku].quantity).toBe(3)
+      expect(cart.current.cartDetails[product1.id].quantity).toBe(2)
+      expect(cart.current.cartDetails[product2.id].quantity).toBe(3)
     })
   })
 
@@ -337,11 +337,11 @@ describe('useShoppingCart()', () => {
 
         act(() => {
           cart.current.addItem(product, startingQuantity)
-          cart.current.setItemQuantity(product.sku, quantity)
+          cart.current.setItemQuantity(product.id, quantity)
         })
 
-        expect(cart.current.cartDetails).toHaveProperty(product.sku)
-        const entry = cart.current.cartDetails[product.sku]
+        expect(cart.current.cartDetails).toHaveProperty(product.id)
+        const entry = cart.current.cartDetails[product.id]
 
         expect(entry.quantity).toBe(quantity)
         expect(entry.value).toBe(product.price * quantity)
@@ -356,10 +356,10 @@ describe('useShoppingCart()', () => {
 
       act(() => {
         cart.current.addItem(product, 10)
-        cart.current.setItemQuantity(product.sku, 0)
+        cart.current.setItemQuantity(product.id, 0)
       })
 
-      expect(cart.current.cartDetails).not.toHaveProperty(product.sku)
+      expect(cart.current.cartDetails).not.toHaveProperty(product.id)
     })
   })
 
@@ -419,7 +419,7 @@ describe('redirectToCheckout()', () => {
     expect(stripeMock.redirectToCheckout).toHaveBeenCalled()
     expect(stripeMock.redirectToCheckout.mock.calls[0][0]).toEqual({
       mode: 'payment',
-      lineItems: [{ price: product.sku, quantity: 1 }],
+      lineItems: [{ price: product.id, quantity: 1 }],
       successUrl: 'https://egghead.io/success',
       cancelUrl: 'https://egghead.io/cancel',
       billingAddressCollection: 'auto',
@@ -441,8 +441,8 @@ describe('redirectToCheckout()', () => {
     await cart.current.redirectToCheckout()
 
     const expectedItems = [
-      { price: product1.sku, quantity: 2 },
-      { price: product2.sku, quantity: 9 }
+      { price: product1.id, quantity: 2 },
+      { price: product2.id, quantity: 9 }
     ]
 
     expect(stripeMock.redirectToCheckout).toHaveBeenCalled()
@@ -511,21 +511,21 @@ describe('checkoutSingleItem()', () => {
 
   it('should send the formatted item with no quantity parameter', async () => {
     const product = mockProduct()
-    await cart.current.checkoutSingleItem({ sku: product.sku })
+    await cart.current.checkoutSingleItem({ sku: product.id })
 
     expect(stripeMock.redirectToCheckout).toHaveBeenCalled()
     expect(stripeMock.redirectToCheckout.mock.calls[0][0].lineItems).toEqual([
-      { price: product.sku, quantity: 1 }
+      { price: product.id, quantity: 1 }
     ])
   })
 
   it('should send the formatted item with a custom quantity parameter', async () => {
     const product = mockProduct()
-    await cart.current.checkoutSingleItem({ sku: product.sku, quantity: 47 })
+    await cart.current.checkoutSingleItem({ sku: product.id, quantity: 47 })
 
     expect(stripeMock.redirectToCheckout).toHaveBeenCalled()
     expect(stripeMock.redirectToCheckout.mock.calls[0][0].lineItems).toEqual([
-      { price: product.sku, quantity: 47 }
+      { price: product.id, quantity: 47 }
     ])
   })
 
@@ -535,7 +535,7 @@ describe('checkoutSingleItem()', () => {
 
     const product = mockProduct()
     expect(
-      cart.current.checkoutSingleItem({ sku: product.sku })
+      cart.current.checkoutSingleItem({ sku: product.id })
     ).rejects.toThrow(
       "Invalid checkout mode 'checkout-session' was chosen. The valid modes are client-only."
     )
@@ -615,13 +615,13 @@ describe('loadCart()', () => {
 
     act(() => {
       cart.current.addItem(product)
-      cart.current.incrementItem(product.sku)
+      cart.current.incrementItem(product.id)
       cart.current.loadCart(cartDetails)
     })
 
-    const entry = cart.current.cartDetails[product.sku]
+    const entry = cart.current.cartDetails[product.id]
     expect(cart.current.cartDetails).toEqual({
-      [entry.sku]: entry,
+      [entry.id]: entry,
       ...cartDetails
     })
     expect(cart.current.totalPrice).toEqual(2200)

--- a/use-shopping-cart/src/reducers.js
+++ b/use-shopping-cart/src/reducers.js
@@ -89,7 +89,7 @@ export function cartValuesReducer(state, action) {
     return {
       cartDetails: {
         ...state.cartDetails,
-        [product.sku]: entry
+        [entry.id]: entry
       },
       totalPrice: state.totalPrice + product.price * count,
       cartCount: state.cartCount + count
@@ -132,8 +132,8 @@ export function cartValuesReducer(state, action) {
   switch (action.type) {
     case 'add-item-to-cart':
       if (action.count <= 0) break
-      if (action.product.sku in state.cartDetails)
-        return updateEntry(action.product.sku, action.count)
+      if (action.product.id in state.cartDetails)
+        return updateEntry(action.product.id, action.count)
       return createEntry(action.product, action.count)
 
     case 'increment-item':

--- a/use-shopping-cart/src/reducers.js
+++ b/use-shopping-cart/src/reducers.js
@@ -11,7 +11,7 @@ export function cartReducer(cart, action) {
     case 'store-last-clicked':
       return {
         ...cart,
-        lastClicked: action.sku
+        lastClicked: action.id
       }
 
     case 'cart-click':
@@ -138,24 +138,24 @@ export function cartValuesReducer(state, action) {
 
     case 'increment-item':
       if (action.count <= 0) break
-      if (action.sku in state.cartDetails)
-        return updateEntry(action.sku, action.count)
+      if (action.id in state.cartDetails)
+        return updateEntry(action.id, action.count)
       break
 
     case 'decrement-item':
       if (action.count <= 0) break
-      if (action.sku in state.cartDetails)
-        return updateEntry(action.sku, -action.count)
+      if (action.id in state.cartDetails)
+        return updateEntry(action.id, -action.count)
       break
 
     case 'set-item-quantity':
       if (action.count < 0) break
-      if (action.sku in state.cartDetails)
-        return updateQuantity(action.sku, action.quantity)
+      if (action.id in state.cartDetails)
+        return updateQuantity(action.id, action.quantity)
       break
 
     case 'remove-item-from-cart':
-      if (action.sku in state.cartDetails) return removeEntry(action.sku)
+      if (action.id in state.cartDetails) return removeEntry(action.id)
       break
 
     case 'clear-cart':

--- a/use-shopping-cart/src/reducers.js
+++ b/use-shopping-cart/src/reducers.js
@@ -61,9 +61,8 @@ function Entry(productData, quantity, currency, language) {
     }
     if (productData.sku) {
       return productData.sku
-    } else {
-      return uuidv4()
     }
+    return uuidv4()
   }
 
   return {

--- a/use-shopping-cart/src/reducers.js
+++ b/use-shopping-cart/src/reducers.js
@@ -1,4 +1,5 @@
 import { formatCurrencyString } from './util'
+import { v4 as uuidv4 } from 'uuid'
 
 export const cartInitialState = {
   lastClicked: '',
@@ -48,8 +49,26 @@ export const cartValuesInitialState = {
   cartCount: 0
 }
 function Entry(productData, quantity, currency, language) {
+  const getProductId = () => {
+    if (productData.id) {
+      return productData.id
+    }
+    if (productData.price_id) {
+      return productData.price_id
+    }
+    if (productData.sku_id) {
+      return productData.sku_id
+    }
+    if (productData.sku) {
+      return productData.sku
+    } else {
+      return uuidv4()
+    }
+  }
+
   return {
     ...productData,
+    id: getProductId(),
     quantity,
     get value() {
       return this.price * this.quantity
@@ -147,8 +166,7 @@ export function cartValuesReducer(state, action) {
 
       for (const sku in action.cartDetails) {
         const entry = action.cartDetails[sku]
-        if (action.filter && !action.filter(entry))
-          continue
+        if (action.filter && !action.filter(entry)) continue
 
         state = createEntry(entry, entry.quantity)
       }

--- a/use-shopping-cart/src/serverUtil.js
+++ b/use-shopping-cart/src/serverUtil.js
@@ -5,15 +5,21 @@ const validateCartItems = (inventorySrc, cartDetails) => {
     const inventoryItem = inventorySrc.find(
       (currentProduct) => currentProduct.sku === sku
     )
-    if (!inventoryItem) throw new Error(`Product ${sku} not found!`)
+    if (!inventoryItem) throw new Error(`Product not found!`)
     const item = {
-      name: inventoryItem.name,
-      amount: inventoryItem.price,
-      currency: inventoryItem.currency,
+      price_data: {
+        currency: inventoryItem.currency,
+        unit_amount: inventoryItem.price,
+        product_data: {
+          name: inventoryItem.name
+        }
+      },
       quantity: product.quantity
     }
-    if (inventoryItem.description) item.description = inventoryItem.description
-    if (inventoryItem.image) item.images = [inventoryItem.image]
+    if (inventoryItem.description)
+      item.price_data.product_data.description = inventoryItem.description
+    if (inventoryItem.image)
+      item.price_data.product_data.images = [inventoryItem.image]
     validatedItems.push(item)
   }
 

--- a/use-shopping-cart/src/serverUtil.js
+++ b/use-shopping-cart/src/serverUtil.js
@@ -5,7 +5,7 @@ const validateCartItems = (inventorySrc, cartDetails) => {
     const product = cartDetails[itemId]
     const inventoryItem = inventorySrc.find(
       (currentProduct) =>
-        currentProduct.sku === sku || currentProduct.id === sku
+        currentProduct.sku === itemId || currentProduct.id === itemId
     )
 
     if (!inventoryItem) throw new Error(`Product ${sku} not found!`)

--- a/use-shopping-cart/src/serverUtil.js
+++ b/use-shopping-cart/src/serverUtil.js
@@ -1,11 +1,15 @@
 const validateCartItems = (inventorySrc, cartDetails) => {
   const validatedItems = []
+
   for (const sku in cartDetails) {
     const product = cartDetails[sku]
     const inventoryItem = inventorySrc.find(
-      (currentProduct) => currentProduct.sku === sku
+      (currentProduct) =>
+        currentProduct.sku === sku || currentProduct.id === sku
     )
-    if (!inventoryItem) throw new Error(`Product not found!`)
+
+    if (!inventoryItem) throw new Error(`Product ${sku} not found!`)
+
     const item = {
       price_data: {
         currency: inventoryItem.currency,
@@ -26,6 +30,18 @@ const validateCartItems = (inventorySrc, cartDetails) => {
   return validatedItems
 }
 
+const formatLineItems = (cartDetails) => {
+  const lineItems = []
+
+  for (const itemId in cartDetails) {
+    if (cartDetails[itemId].sku_id || cartDetails[itemId].price_id)
+      lineItems.push({ price: itemId, quantity: cartDetails[itemId].quantity })
+  }
+
+  return lineItems
+}
+
 module.exports = {
-  validateCartItems
+  validateCartItems,
+  formatLineItems
 }

--- a/use-shopping-cart/src/serverUtil.js
+++ b/use-shopping-cart/src/serverUtil.js
@@ -8,7 +8,7 @@ const validateCartItems = (inventorySrc, cartDetails) => {
         currentProduct.sku === itemId || currentProduct.id === itemId
     )
 
-    if (!inventoryItem) throw new Error(`Product ${sku} not found!`)
+    if (!inventoryItem) throw new Error(`Product ${itemId} not found!`)
 
     const item = {
       price_data: {

--- a/use-shopping-cart/src/serverUtil.js
+++ b/use-shopping-cart/src/serverUtil.js
@@ -1,8 +1,8 @@
 const validateCartItems = (inventorySrc, cartDetails) => {
   const validatedItems = []
 
-  for (const sku in cartDetails) {
-    const product = cartDetails[sku]
+  for (const itemId in cartDetails) {
+    const product = cartDetails[itemId]
     const inventoryItem = inventorySrc.find(
       (currentProduct) =>
         currentProduct.sku === sku || currentProduct.id === sku

--- a/use-shopping-cart/src/serverUtil.js
+++ b/use-shopping-cart/src/serverUtil.js
@@ -20,13 +20,20 @@ const validateCartItems = (inventorySrc, cartDetails) => {
       },
       quantity: product.quantity
     }
-    if (inventoryItem.price_data) item.price_data = { ...price_data }
-    if (inventoryItem.product_data)
-      item.price_data.product_data = { ...product_data }
     if (inventoryItem.description)
       item.price_data.product_data.description = inventoryItem.description
     if (inventoryItem.image)
       item.price_data.product_data.images = [inventoryItem.image]
+    if (inventoryItem.price_data)
+      item.price_data = {
+        ...item.price_data,
+        ...inventoryItem.price_data
+      }
+    if (inventoryItem.product_data)
+      item.price_data.product_data = {
+        ...item.price_data.product_data,
+        ...inventoryItem.product_data
+      }
     validatedItems.push(item)
   }
 

--- a/use-shopping-cart/src/serverUtil.js
+++ b/use-shopping-cart/src/serverUtil.js
@@ -20,6 +20,9 @@ const validateCartItems = (inventorySrc, cartDetails) => {
       },
       quantity: product.quantity
     }
+    if (inventoryItem.price_data) item.price_data = { ...price_data }
+    if (inventoryItem.product_data)
+      item.price_data.product_data = { ...product_data }
     if (inventoryItem.description)
       item.price_data.product_data.description = inventoryItem.description
     if (inventoryItem.image)

--- a/use-shopping-cart/src/serverUtil.test.js
+++ b/use-shopping-cart/src/serverUtil.test.js
@@ -23,7 +23,8 @@ const mockSku = {
   price: 200,
   image: 'https://www.fillmurray.com/300/300',
   currency: 'usd',
-  sku_id: 'sku_abc123'
+  sku_id: 'sku_abc123',
+  product_data: { metadata: { type: 'test' } }
 }
 
 const mockSku2 = {
@@ -43,7 +44,8 @@ const mockDetailedSku = {
     image: mockSku.image,
     value: 200,
     name: 'Banana',
-    sku_id: 'sku_abc123'
+    sku_id: 'sku_abc123',
+    product_data: { metadata: { type: 'test' } }
   }
 }
 
@@ -103,6 +105,50 @@ describe('validateCartItems', () => {
       }
     ])
   })
+
+  it('Properly spreads product_data from the product object into price_data.product_data', () => {
+    inventory[0].product_data = { metadata: { type: 'test' } }
+    expect(validateCartItems(inventory, { ...mockDetailedSku })).toStrictEqual([
+      {
+        price_data: {
+          currency: inventory[0].currency,
+          unit_amount: 400,
+          product_data: {
+            name: inventory[0].name,
+            description: 'Yummy yellow fruit',
+            images: ['https: //www.fillmurray.com/300/300'],
+            metadata: {
+              type: 'test'
+            }
+          }
+        },
+        quantity: mockDetailedSku[inventory[0].sku].quantity
+      }
+    ])
+  })
+
+  it('Properly spreads price_data from the product object into price_data', () => {
+    inventory[0].price_data = { metadata: { type: 'test' } }
+    expect(validateCartItems(inventory, { ...mockDetailedSku })).toStrictEqual([
+      {
+        price_data: {
+          currency: inventory[0].currency,
+          unit_amount: 400,
+          metadata: { type: 'test' },
+          product_data: {
+            name: inventory[0].name,
+            description: 'Yummy yellow fruit',
+            images: ['https: //www.fillmurray.com/300/300'],
+            metadata: {
+              type: 'test'
+            }
+          }
+        },
+        quantity: mockDetailedSku[inventory[0].sku].quantity
+      }
+    ])
+  })
+
   it('throws an error if product does not exist in inventory', () => {
     expect(() => {
       validateCartItems(inventory, { sku_1234: { sku: 'sku_1234' } })

--- a/use-shopping-cart/src/serverUtil.test.js
+++ b/use-shopping-cart/src/serverUtil.test.js
@@ -1,4 +1,4 @@
-import { validateCartItems } from './serverUtil'
+import { validateCartItems, formatLineItems } from './serverUtil'
 
 const inventory = [
   {
@@ -22,7 +22,8 @@ const mockSku = {
   name: 'Banana',
   price: 200,
   image: 'https://www.fillmurray.com/300/300',
-  currency: 'usd'
+  currency: 'usd',
+  sku_id: 'sku_abc123'
 }
 
 const mockSku2 = {
@@ -41,7 +42,8 @@ const mockDetailedSku = {
     formattedValue: '$2.00',
     image: mockSku.image,
     value: 200,
-    name: 'Banana'
+    name: 'Banana',
+    sku_id: 'sku_abc123'
   }
 }
 
@@ -58,23 +60,45 @@ const mockDetailedSku2 = {
   }
 }
 
+const mockPrice = {
+  price_id: 'price_123',
+  unit_amount: 350,
+  currency: 'USD',
+  name: 'Pants'
+}
+
+const mockDetailedPrice = {
+  [mockPrice.price_id]: {
+    ...mockPrice,
+    quantity: 5
+  }
+}
+
 describe('validateCartItems', () => {
   it('matches on SKU & references the correct price & sets description + images if present', () => {
     expect(
       validateCartItems(inventory, { ...mockDetailedSku, ...mockDetailedSku2 })
     ).toStrictEqual([
       {
-        name: inventory[0].name,
-        description: 'Yummy yellow fruit',
-        amount: 400,
-        currency: inventory[0].currency,
-        quantity: mockDetailedSku[inventory[0].sku].quantity,
-        images: ['https: //www.fillmurray.com/300/300']
+        price_data: {
+          currency: inventory[0].currency,
+          unit_amount: 400,
+          product_data: {
+            name: inventory[0].name,
+            description: 'Yummy yellow fruit',
+            images: ['https: //www.fillmurray.com/300/300']
+          }
+        },
+        quantity: mockDetailedSku[inventory[0].sku].quantity
       },
       {
-        name: inventory[1].name,
-        amount: 100,
-        currency: inventory[1].currency,
+        price_data: {
+          currency: inventory[1].currency,
+          unit_amount: 100,
+          product_data: {
+            name: inventory[1].name
+          }
+        },
         quantity: mockDetailedSku2[inventory[1].sku].quantity
       }
     ])
@@ -83,5 +107,19 @@ describe('validateCartItems', () => {
     expect(() => {
       validateCartItems(inventory, { sku_1234: { sku: 'sku_1234' } })
     }).toThrow('Product sku_1234 not found!')
+  })
+})
+
+describe('formatLineItems', () => {
+  it('Formats line items with price_id appropriately', () => {
+    expect(formatLineItems(mockDetailedPrice)).toStrictEqual([
+      { price: 'price_123', quantity: 5 }
+    ])
+  })
+
+  it('Formats line items with sku_id appropriately', () => {
+    expect(formatLineItems(mockDetailedSku)).toStrictEqual([
+      { price: 'sku_abc123', quantity: 3 }
+    ])
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -21147,6 +21147,13 @@ use-callback-ref@^1.2.1, use-callback-ref@^1.2.3:
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.4.tgz#d86d1577bfd0b955b6e04aaf5971025f406bea3c"
   integrity sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==
 
+use-shopping-cart@*:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/use-shopping-cart/-/use-shopping-cart-2.2.0.tgz#aee9be0cc26a25f0668fd224328bd525386e315e"
+  integrity sha512-/3CeEVdGPZuVaKO3zMzwTykmaOpk0tVa8AqLS4O2RDLn7PTDkzThqil+hDJySI4lnUjjcwQso2O8dBOYIaSqMg==
+  dependencies:
+    react-storage-hooks "^4.0.0"
+
 use-sidecar@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.3.tgz#17a4e567d4830c0c0ee100040e85a7fe68611e0f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21229,6 +21229,11 @@ uuid@^8.0.0, uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
 
+uuid@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
+  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+
 v8-compile-cache@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz#8d32e4f16974654657e676e0e467a348e89b0dc4"


### PR DESCRIPTION
This is a working example of how session IDs should be created. Right now, this does not take care of the case for products that are created in the Stripe dashboard, this is for when products are NOT in the Stripe dashboard.

Changes:
1. Added "mode" to serverless function. There are 3 modes: `setup`, `payment` and `subscription`. We won't worry about this, this will be up to a consumer to handle. For now I'm just using `payment`

2. Validate Cart items is now formatted for V2 of Stripe session ID creation, however, we need this to be aware of situations when a user *is* using the stripe dashboard for their products. The API is way more simple, just need to pass the priceID and the quantity

3. Updated images because they weren't secure before, with Fill Murray


I'm going to continue on this, just wanted to put it up early for feedback in the mean time.

