### PR TITLE
Fix typos in incrementItem documentation

### DIFF
--- a/documentation/src/docs/usage/incrementItem().mdx
+++ b/documentation/src/docs/usage/incrementItem().mdx
@@ -1,11 +1,11 @@
 ---
-title: incremementItem()
+title: incrementItem()
 ---
 
 import CartDisplayWrapper from 'components/cart-display-wrapper'
 import IncrementItem from 'components/increment-item'
 
-`incrementItem(sku, quantity = 1)` takes a sku of a product in the cart and incremements the quantity by 1 by default.
+`incrementItem(sku, quantity = 1)` takes a sku of a product in the cart and increments the quantity by 1 by default.
 
 You can pass an optional quantity for the second param to increase by that number. For example:
 


### PR DESCRIPTION
Fixing a typo where the docs were saying "Incremement" like in the below screenshot:
![Documentation page title saying "incremementItem"](https://user-images.githubusercontent.com/19195374/100812803-807aa680-3403-11eb-8e7a-1c805cb9dab8.png)
