### PR TITLE
(docs): fix totalPrice is not a function

### DIFF
--- a/documentation/src/docs/getting-started.mdx
+++ b/documentation/src/docs/getting-started.mdx
@@ -86,7 +86,7 @@ export function App() {
 
       {/* This is where we'll render our cart */}
       <p>Number of Items: {cartCount}</p>
-      <p>Total: {totalPrice()}</p>
+      <p>Total: {totalPrice}</p>
       <CartItems />
 
       {/* Redirects the user to Stripe */}


### PR DESCRIPTION
- when going through the getting started documentation I got an error that totalPrice is not a function. Removing the function call fixed this for me.  I assume it used to be a function and no longer is?