### PR TITLE
Allow react 16 or 17

### DIFF
--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -25,7 +25,7 @@
     "dev": "ntl dev"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.1"
+    "react": ">=16.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -25,7 +25,7 @@
     "dev": "ntl dev"
   },
   "peerDependencies": {
-    "react": "16.13.1"
+    "react": "^16.13.1 || ^17.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
Change the React peerDependency to allow either >= 16.13.1 or >= 17.0.1. This is required since npm 7 now enforces the versions supplied in the peerDependencies field for packages.