### PR TITLE
(docs): add missing mode prop

### DIFF
--- a/documentation/src/docs/getting-started.mdx
+++ b/documentation/src/docs/getting-started.mdx
@@ -29,6 +29,7 @@ const stripePromise = loadStripe(process.env.REACT_APP_STRIPE_API_PUBLIC)
 
 ReactDOM.render(
   <CartProvider
+    mode="client-only"
     stripe={stripePromise}
     successUrl="stripe.com"
     cancelUrl="twitter.com/dayhaysoos"


### PR DESCRIPTION
- Adds a missing mode prop to the CartProvider in the getting started section of the docs
- Closed my other PR since it was a mess, and opened this one.