### PR TITLE
(docs): add basic docs for cart display management

### DIFF
--- a/documentation/src/docs/usage/api.mdx
+++ b/documentation/src/docs/usage/api.mdx
@@ -30,8 +30,10 @@ Total price of all products in cart
 
 ## `handleCartClick`, `handleCloseCart` and `shouldDisplayCart`
 
-`shouldDisplayCart`: Boolean value which can be used to manage the cart's displayed or undisplayed state.
+These three API items provide basic state management for your cart. The cart state is stored in the `shouldDisplayCart` variable. The two functions can be used to update this state.
 
-`handleCartClick`: Function which toggles the displayed state for the cart, updates `shouldDisplayCart`.
+`shouldDisplayCart`: Boolean value which can be used to handle the cart's displayed or undisplayed state.
+
+`handleCartClick`: Function which toggles the displayed state for the cart between true and false, updates `shouldDisplayCart`.
 
 `handleCloseCart`: Function which sets the displayed cart state to false, updates `shouldDisplayCart`.

--- a/documentation/src/docs/usage/api.mdx
+++ b/documentation/src/docs/usage/api.mdx
@@ -27,3 +27,11 @@ Total number of items in the cart
 Total price of all products in cart
 
 <API />
+
+## `handleCartClick`, `handleCloseCart` and `shouldDisplayCart`
+
+`shouldDisplayCart`: Boolean value which can be used to manage the cart's displayed or undisplayed state.
+
+`handleCartClick`: Function which toggles the displayed state for the cart, updates `shouldDisplayCart`.
+
+`handleCloseCart`: Function which sets the displayed cart state to false, updates `shouldDisplayCart`.


### PR DESCRIPTION
Related: #151 

Very basic documentation for `shouldDisplayCart`, `handleCartClick` and `handleCloseCart`. 

 It is too late for this change now, but in my opinion it would have been more intuitive to name it as `handleCartClose` so it was similarly named to `handleCartClick`. Not a big deal, but caught me off guard.