### PR TITLE
Touching up the Redux branch

### DIFF
--- a/examples/cra/src/components/cart-display.js
+++ b/examples/cra/src/components/cart-display.js
@@ -30,7 +30,7 @@ const CartDisplay = () => {
     redirectToCheckout({ sessionId: response.sessionId })
   }
 
-  if (Object.keys(cartDetails).length === 0) {
+  if (cartCount === 0) {
     return (
       <Box sx={{ textAlign: 'center' }}>
         <h2>Shopping Cart Display Panel</h2>

--- a/examples/cra/src/store.js
+++ b/examples/cra/src/store.js
@@ -1,8 +1,0 @@
-import { configureStore } from '@reduxjs/toolkit'
-import cartReducer from 'use-shopping-cart/src/core/slices/cartSlice'
-
-export default configureStore({
-  reducer: {
-    cart: cartReducer
-  }
-})

--- a/use-shopping-cart/.eslintrc
+++ b/use-shopping-cart/.eslintrc
@@ -24,7 +24,10 @@
     "curly": ["warn", "multi-or-nest"],
     "arrow-parens": "warn",
     "react/prop-types": "off",
-    "object-curly-spacing": ["error", "always"]
+    "object-curly-spacing": ["error", "always"],
+    "camelcase": ["error", {
+      "allow": ["price_metadata", "product_metadata"]
+    }]
   },
   "ignorePatterns": ["*.d.ts"]
 }

--- a/use-shopping-cart/core/Entry.js
+++ b/use-shopping-cart/core/Entry.js
@@ -1,4 +1,4 @@
-import { formatCurrencyString } from './store'
+import { formatCurrencyString } from '../utilities/old-utils'
 import { v4 as uuidv4 } from 'uuid'
 
 function Entry({

--- a/use-shopping-cart/core/slice.js
+++ b/use-shopping-cart/core/slice.js
@@ -40,6 +40,7 @@ const slice = createSlice({
             'addItem requires the count to be greater than zero.',
             action
           )
+          return
         }
 
         if (id in state.cartDetails) {

--- a/use-shopping-cart/core/store.js
+++ b/use-shopping-cart/core/store.js
@@ -1,33 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { reducer, actions, initialState } from './slice'
-import { isClient } from '../utilities/SSR'
+import { filterCart, formatCurrencyString } from '../utilities/old-utils'
 
-export const formatCurrencyString = ({
-  value,
-  currency,
-  language = isClient ? navigator.language : 'en-US'
-}) => {
-  value = parseInt(value)
-  const numberFormat = new Intl.NumberFormat(language, {
-    style: 'currency',
-    currency,
-    currencyDisplay: 'symbol'
-  })
-  const parts = numberFormat.formatToParts(value)
-  let zeroDecimalCurrency = true
-
-  for (const part of parts) {
-    if (part.type === 'decimal') {
-      zeroDecimalCurrency = false
-      break
-    }
-  }
-
-  value = zeroDecimalCurrency ? value : value / 100
-  return numberFormat.format(value.toFixed(2))
-}
-
-export { reducer, actions }
+export { reducer, actions, filterCart, formatCurrencyString }
 export function createShoppingCartStore(options) {
   return configureStore({
     reducer,

--- a/use-shopping-cart/jest.config.js
+++ b/use-shopping-cart/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  env: 'jsdom',
+  roots: ['react', 'core', 'utilities']
+}

--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -34,8 +34,8 @@
     "npm": ">=5"
   },
   "scripts": {
-    "test": "cross-env CI=1 SKIP_PREFLIGHT_CHECK=true react-scripts test --env=jsdom",
-    "test:watch": "react-scripts test --env=jsdom",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "build": "rollup -c",
     "start": "rollup -c -w & (yarn workspace use-shopping-cart-cra start)",
     "prepare": "yarn run build",

--- a/use-shopping-cart/react/index.js
+++ b/use-shopping-cart/react/index.js
@@ -1,12 +1,13 @@
 import * as React from 'react'
 import { actions, initialState } from '../core/slice'
-import { createShoppingCartStore } from '../core/store'
+import {
+  createShoppingCartStore,
+  formatCurrencyString,
+  filterCart
+} from '../core/store'
 import { createDispatchHook, createSelectorHook, Provider } from 'react-redux'
-import { checkoutHandler, filterCart } from '../utilities/old-utils'
-//TODO figure out how to apply formatCurrencyString
-import { formatCurrencyString } from '../core/store'
 
-export { actions, filterCart }
+export { actions, filterCart, formatCurrencyString }
 export const CartContext = React.createContext(initialState)
 export const useSelector = createSelectorHook(CartContext)
 export const useDispatch = createDispatchHook(CartContext)
@@ -33,12 +34,17 @@ export function useShoppingCart(
   const dispatch = useDispatch()
   const cartState = useSelector(selector, equalityFn)
 
-  // Add action dispatchors
-  for (const key in actions)
-    cartState[key] = (...args) => dispatch(actions[key](...args))
+  const shoppingCart = React.useMemo(() => {
+    // Add action dispatchors
+    const cartActions = {}
+    for (const key in actions)
+      cartActions[key] = (...args) => dispatch(actions[key](...args))
 
-  React.useDebugValue(cartState)
-  return cartState
+    return { ...cartState, ...cartActions }
+  }, [cartState, dispatch])
+
+  React.useDebugValue(shoppingCart)
+  return shoppingCart
 }
 
 export function DebugCart(props) {

--- a/use-shopping-cart/utilities/old-utils.test.js
+++ b/use-shopping-cart/utilities/old-utils.test.js
@@ -1,8 +1,4 @@
-import {
-  formatCurrencyString,
-  getCheckoutData,
-  filterCart
-} from '../core/store'
+import { formatCurrencyString, getCheckoutData, filterCart } from './old-utils'
 
 describe('getCheckoutData', () => {
   const cart = {


### PR DESCRIPTION
I have added a few things here and there to make the Redux branch a little better. I've also been merging repeatedly to keep up with the changes so I'm not completely sure that everything is the way it should be. However, I feel that there were a lot of little things in the Redux branch that were misconfigured and this PR should fix them.

- Updated .eslintrc to allow `price_metadata` and `product_metadata` even though they're not camelCased. (if you can't see errors like these I would suggest turning on ESLint in your code editor).
 - also added `"object-curly-spacing"`
- Remove duplication of `formatCurrencyString` and import it from utilities in `store.js`. Export utilities from `store.js`
- Import universal utilities from `store.js` and re-export them.
- Memoize the `shoppingCart`
- `initialState` instead of `initialCartState`
- `console.warn` when things go wrong in reducers and then `return`