### PR TITLE
Import uuid browser build directly to be independent of Node crypto package

### DIFF
--- a/use-shopping-cart/core/Entry.js
+++ b/use-shopping-cart/core/Entry.js
@@ -1,5 +1,5 @@
 import { formatCurrencyString } from '../utilities/old-utils'
-import { v4 as uuidv4 } from 'uuid'
+import { v4 as uuidv4 } from 'uuid/dist/esm-browser/index.js'
 
 function Entry({
   product,

--- a/use-shopping-cart/core/slice.js
+++ b/use-shopping-cart/core/slice.js
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { createEntry, updateEntry, removeEntry, updateQuantity } from './Entry'
 import { isClient } from '../utilities/SSR'
-import { v4 as uuidv4 } from 'uuid'
+import { v4 as uuidv4 } from 'uuid/dist/esm-browser/index.js'
 
 export const initialState = {
   mode: 'checkout-session',

--- a/use-shopping-cart/rollup.config.js
+++ b/use-shopping-cart/rollup.config.js
@@ -8,7 +8,7 @@ import pkg from './package.json'
 export default [
   {
     input: './react/index.js',
-    external: ['react', 'crypto'],
+    external: ['react'],
     output: [
       {
         file: pkg.exports['.'].require,
@@ -40,7 +40,6 @@ export default [
   },
   {
     input: './core/store.js',
-    external: ['uuid'],
     output: [
       {
         file: pkg.exports['./core'].require,

--- a/use-shopping-cart/rollup.config.js
+++ b/use-shopping-cart/rollup.config.js
@@ -25,7 +25,7 @@ export default [
         file: pkg.exports['.'].browser,
         format: 'umd',
         sourcemap: true,
-        globals: { react: 'React', crypto: 'crypto' }
+        globals: { react: 'React' }
       }
     ],
     plugins: [
@@ -59,8 +59,7 @@ export default [
         format: 'umd',
         sourcemap: true,
         globals: {
-          react: 'React',
-          uuid: 'uuid'
+          react: 'React'
         }
       }
     ],


### PR DESCRIPTION
Switched from importing `uuid` regularly to importing the browser build for `uuid`. And removed both `uuid` and `crypto` from Rollup config `externals`.

```js
// old
import { v4 as uuidv4 } from 'uuid'

// new
import { v4 as uuidv4 } from 'uuid/dist/esm-browser/index.js'
```

## To-Do

This change still needs to be tested in some manner that proves that it actually fixes #184 instead of causing more problems. It would also be good to test this in an SSR situation to ensure that this doesn't break SSR.
