### PR TITLE
switch "mode" to cartMode

### DIFF
--- a/examples/cra/src/index.js
+++ b/examples/cra/src/index.js
@@ -7,7 +7,8 @@ import App from './App'
 
 ReactDOM.render(
   <CartProvider
-    mode="checkout-session"
+    mode="payment"
+    cartMode="checkout-session"
     stripe={process.env.REACT_APP_STRIPE_API_PUBLIC}
     billingAddressCollection={false}
     successUrl="https://stripe.com"

--- a/use-shopping-cart/core/slice.js
+++ b/use-shopping-cart/core/slice.js
@@ -4,7 +4,8 @@ import { isClient } from '../utilities/SSR'
 import { v4 as uuidv4 } from 'uuid'
 
 export const initialState = {
-  mode: 'checkout-session',
+  cartMode: 'checkout-session',
+  mode: 'payment',
   currency: 'USD',
   language: isClient ? navigator.language : 'en-US',
   lastClicked: '',
@@ -177,6 +178,9 @@ const slice = createSlice({
     checkoutSingleItem: {
       reducer: (state) => {
         return state
+      },
+      prepare: (productId) => {
+        return { payload: { productId } }
       }
     },
     handleCartHover: (state) => {

--- a/use-shopping-cart/core/stripe-middleware.js
+++ b/use-shopping-cart/core/stripe-middleware.js
@@ -18,9 +18,34 @@ export const handleStripe = (store) => (next) => async (action) => {
       })
     }
 
-    if (store.getState().mode === 'client-only') {
+    if (cart.cartMode === 'client-only') {
       const checkoutData = getCheckoutData(cart)
       stripe.redirectToCheckout(checkoutData)
+    }
+  }
+
+  if (action.type === 'cart/checkoutSingleItem') {
+    try {
+      stripe = await loadStripe(stripePublicKey)
+    } catch (error) {
+      console.log('error', error)
+    }
+
+    if (action.payload?.sessionId) {
+      return stripe.redirectToCheckout({
+        sessionId: action.payload.sessionId
+      })
+    }
+
+    if (cart.cartMode === 'client-only') {
+      const productId = action.payload.productId
+      const options = {
+        mode: cart.mode,
+        successUrl: cart.successUrl,
+        cancelUrl: cart.cancelUrl,
+        lineItems: [{ price: productId, quantity: 1 }]
+      }
+      stripe.redirectToCheckout(options)
     }
   }
   try {

--- a/use-shopping-cart/core/stripe-middleware.js
+++ b/use-shopping-cart/core/stripe-middleware.js
@@ -12,7 +12,7 @@ export const handleStripe = (store) => (next) => async (action) => {
     } catch (error) {
       console.log('error', error)
     }
-    if (action.payload?.sessionId) {
+    if (cart.cartMode === 'checkout-session') {
       return stripe.redirectToCheckout({
         sessionId: action.payload.sessionId
       })
@@ -22,6 +22,8 @@ export const handleStripe = (store) => (next) => async (action) => {
       const checkoutData = getCheckoutData(cart)
       stripe.redirectToCheckout(checkoutData)
     }
+
+    throw new Error(`Invalid value for "cartMode" was found: ${cart.cartMode}`)
   }
 
   if (action.type === 'cart/checkoutSingleItem') {
@@ -31,10 +33,9 @@ export const handleStripe = (store) => (next) => async (action) => {
       console.log('error', error)
     }
 
-    if (action.payload?.sessionId) {
-      return stripe.redirectToCheckout({
-        sessionId: action.payload.sessionId
-      })
+    if (cart.cartMode !== 'client-only') {
+      console.warn('checkoutSingleItem only works with client-only mode')
+      return
     }
 
     if (cart.cartMode === 'client-only') {
@@ -48,9 +49,5 @@ export const handleStripe = (store) => (next) => async (action) => {
       stripe.redirectToCheckout(options)
     }
   }
-  try {
-    return next(action)
-  } catch (error) {
-    console.error('Error:', error)
-  }
+  return next(action)
 }


### PR DESCRIPTION
Stripe's session creation API accepts a `mode` already and is required for the price API. We should probably stick as close to possible to the required config by Stripe, so I think `mode` should only be taking strings like `payment`, `setup` or `subscribe`

https://stripe.com/docs/api/checkout/sessions/create

So as far as the cart set up, I think we should switch it to be named `cartMode` instead.