### PR TITLE
Fix redux-persist error message

### DIFF
--- a/use-shopping-cart/.eslintrc
+++ b/use-shopping-cart/.eslintrc
@@ -29,5 +29,5 @@
       "allow": ["price_metadata", "product_metadata", "price_data", "product_data", "unit_amount"]
     }]
   },
-  "ignorePatterns": ["*.d.ts"]
+  "ignorePatterns": ["*.d.ts", "node_modules", "dist"]
 }

--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -39,7 +39,8 @@
     "build": "rollup -c",
     "build:watch": "rollup -c -w",
     "prepare": "yarn run build",
-    "predeploy": "yarn workspace install && yarn run build"
+    "predeploy": "yarn workspace install && yarn run build",
+    "lint": "eslint --fix '**/*.js'"
   },
   "peerDependencies": {
     "react": ">=16.8.0"


### PR DESCRIPTION
Fixes #180.

The default import for `'redux-persist/lib/storage'` is `createWebStorage('local')` which calls `getStorage` which is causing this error. I replaced this import with my own `createLocalStorage` function.

I also added an option to allow the end-developer to use their own custom `storage`.