### PR TITLE
Serverless updates

### DIFF
--- a/use-shopping-cart/utilities/serverless.js
+++ b/use-shopping-cart/utilities/serverless.js
@@ -1,13 +1,15 @@
 function validateCartItems(inventorySrc, cartDetails) {
   const validatedItems = []
 
-  for (const itemId in cartDetails) {
-    const product = cartDetails[itemId]
+  for (const id in cartDetails) {
     const inventoryItem = inventorySrc.find(
-      (currentProduct) =>
-        currentProduct.sku === itemId || currentProduct.id === itemId
+      (currentProduct) => currentProduct.id === id
     )
-    if (!inventoryItem) throw new Error(`Product ${itemId} not found!`)
+    if (inventoryItem === undefined) {
+      throw new Error(
+        `Invalid Cart: product with id "${id}" is not in your inventory.`
+      )
+    }
 
     const item = {
       price_data: {
@@ -19,13 +21,26 @@ function validateCartItems(inventorySrc, cartDetails) {
         },
         ...inventoryItem.price_data
       },
-      quantity: product.quantity
+      quantity: cartDetails[id].quantity
     }
 
-    if (inventoryItem.description)
+    if (typeof cartDetails[id].product_data?.metadata === 'object') {
+      item.price_data.product_data.metadata = {
+        ...item.price_data.product_data.metadata,
+        ...cartDetails[id].product_data.metadata
+      }
+    }
+
+    if (
+      typeof inventoryItem.description === 'string' &&
+      inventoryItem.description.length > 0
+    )
       item.price_data.product_data.description = inventoryItem.description
 
-    if (inventoryItem.image)
+    if (
+      typeof inventoryItem.image === 'string' &&
+      inventoryItem.image.length > 0
+    )
       item.price_data.product_data.images = [inventoryItem.image]
 
     validatedItems.push(item)
@@ -36,13 +51,8 @@ function validateCartItems(inventorySrc, cartDetails) {
 
 function formatLineItems(cartDetails) {
   const lineItems = []
-
-  for (const itemId in cartDetails) {
-    const item = cartDetails[itemId]
-
-    if (cartDetails[itemId].id)
-      lineItems.push({ price: itemId, quantity: cartDetails[itemId].quantity })
-  }
+  for (const id in cartDetails)
+    lineItems.push({ price: id, quantity: cartDetails[id].quantity })
 
   return lineItems
 }

--- a/use-shopping-cart/utilities/serverless.test.js
+++ b/use-shopping-cart/utilities/serverless.test.js
@@ -2,170 +2,223 @@ import { validateCartItems, formatLineItems } from './serverless'
 
 const inventory = [
   {
-    name: 'Banana',
-    description: 'Yummy yellow fruit',
-    sku: 'sku_abc123',
+    id: 'price_bananas',
     price: 400,
-    image: 'https: //www.fillmurray.com/300/300',
-    currency: 'USD'
+    currency: 'USD',
+    name: 'Bananas',
+    description: 'Yummy yellow fruit',
+    image:
+      'https://images.unsplash.com/photo-1571771894821-ce9b6c11b08e?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1400&q=80',
+    product_data: {
+      metadata: { availability: 'limited time', type: 'fruit' }
+    }
   },
   {
-    name: 'Banana',
-    sku: 'sku_xyz456',
+    id: 'price_oranges',
     price: 100,
-    currency: 'USD'
+    currency: 'USD',
+    name: 'Oranges',
+    description: 'Juicy orange fruit',
+    image:
+      'https://images.unsplash.com/photo-1547514701-42782101795e?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=934&q=80'
+  },
+  {
+    id: 'id_donation',
+    price: 2000,
+    currency: 'USD',
+    name: 'One-Time Charitable Donation'
+  },
+  {
+    id: 'id_burger',
+    price: 850,
+    currency: 'USD',
+    name: 'Burger',
+    image:
+      'https://images.unsplash.com/photo-1568901346375-23c9450c58cd?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1502&q=80',
+    product_data: {
+      metadata: { type: 'meal' }
+    }
   }
 ]
 
-const mockSku = {
-  sku: 'sku_abc123',
-  name: 'Banana',
-  price: 200,
-  image: 'https://www.fillmurray.com/300/300',
-  currency: 'usd',
-  sku_id: 'sku_abc123',
-  product_data: { metadata: { type: 'test' } }
-}
-
-const mockSku2 = {
-  sku: 'sku_xyz456',
-  price: 300,
-  currency: 'USD',
-  name: 'Banana'
-}
-
-const mockDetailedSku = {
-  [mockSku.sku]: {
-    sku: mockSku.sku,
-    quantity: 3,
-    currency: mockSku.currency,
-    price: mockSku.price,
-    formattedValue: '$2.00',
-    image: mockSku.image,
-    value: 200,
-    name: 'Banana',
-    sku_id: 'sku_abc123',
-    product_data: { metadata: { type: 'test' } }
-  }
-}
-
-const mockDetailedSku2 = {
-  [mockSku2.sku]: {
-    sku: mockSku2.sku,
+const cartDetails = {
+  // eslint-disable-next-line camelcase
+  price_bananas: {
+    id: 'price_bananas',
+    price: 400,
+    currency: 'USD',
+    name: 'Bananas',
+    description: 'Yummy yellow fruit',
+    image:
+      'https://images.unsplash.com/photo-1571771894821-ce9b6c11b08e?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1400&q=80',
     quantity: 1,
-    currency: mockSku2.currency,
-    price: mockSku2.price,
-    formattedValue: '$3.00',
-    image: mockSku2.image,
-    value: 300,
-    name: 'Banana'
-  }
-}
-
-const mockPrice = {
-  price_id: 'price_123',
-  unit_amount: 350,
-  currency: 'USD',
-  name: 'Pants'
-}
-
-const mockDetailedPrice = {
-  [mockPrice.price_id]: {
-    ...mockPrice,
-    quantity: 5
+    value: 400,
+    formattedValue: '$4.00',
+    product_data: {
+      metadata: { availability: 'limited time', type: 'fruit' }
+    }
+  },
+  // eslint-disable-next-line camelcase
+  price_oranges: {
+    id: 'price_oranges',
+    price: 100,
+    currency: 'USD',
+    name: 'Oranges',
+    description: 'Juicy orange fruit',
+    image:
+      'https://images.unsplash.com/photo-1547514701-42782101795e?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=934&q=80',
+    quantity: 2,
+    value: 200,
+    formattedValue: '$2.00',
+    price_data: {},
+    product_data: {}
+  },
+  // eslint-disable-next-line camelcase
+  id_donation: {
+    id: 'donation',
+    price: 2000,
+    currency: 'USD',
+    name: 'One-Time Charitable Donation',
+    quantity: 1,
+    value: 2000,
+    formattedValue: '$20.00',
+    price_data: {},
+    product_data: {}
+  },
+  // eslint-disable-next-line camelcase
+  id_burger: {
+    id: 'id_burger',
+    price: 850,
+    currency: 'USD',
+    name: 'Burger',
+    image:
+      'https://images.unsplash.com/photo-1568901346375-23c9450c58cd?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1502&q=80',
+    quantity: 1,
+    value: 850,
+    formattedValue: '$8.50',
+    price_data: {},
+    product_data: {
+      metadata: {
+        type: 'meal',
+        // eslint-disable-next-line camelcase
+        order_id: '6753',
+        // eslint-disable-next-line camelcase
+        extra_toppings: 'jalapeños, mustard, mayo, caramelized onions'
+      }
+    }
   }
 }
 
 describe('validateCartItems', () => {
-  it('matches on SKU & references the correct price & sets description + images if present', () => {
-    expect(
-      validateCartItems(inventory, { ...mockDetailedSku, ...mockDetailedSku2 })
-    ).toStrictEqual([
-      {
-        price_data: {
-          currency: inventory[0].currency,
-          unit_amount: 400,
-          product_data: {
-            name: inventory[0].name,
-            description: 'Yummy yellow fruit',
-            images: ['https: //www.fillmurray.com/300/300']
-          }
-        },
-        quantity: mockDetailedSku[inventory[0].sku].quantity
+  const lineItems = validateCartItems(inventory, cartDetails)
+
+  it('should set the currency, unit_amount, name, and quantity correctly', () => {
+    expect(lineItems[2]).toStrictEqual({
+      price_data: {
+        currency: 'USD',
+        unit_amount: 2000,
+        product_data: {
+          name: 'One-Time Charitable Donation'
+        }
       },
-      {
-        price_data: {
-          currency: inventory[1].currency,
-          unit_amount: 100,
-          product_data: {
-            name: inventory[1].name
-          }
-        },
-        quantity: mockDetailedSku2[inventory[1].sku].quantity
-      }
-    ])
+      quantity: 1
+    })
   })
 
-  it('Properly spreads product_data from the product object into price_data.product_data', () => {
-    inventory[0].product_data = { metadata: { type: 'test' } }
-    expect(validateCartItems(inventory, { ...mockDetailedSku })).toStrictEqual([
-      {
-        price_data: {
-          currency: inventory[0].currency,
-          unit_amount: 400,
-          product_data: {
-            name: inventory[0].name,
-            description: 'Yummy yellow fruit',
-            images: ['https: //www.fillmurray.com/300/300'],
-            metadata: {
-              type: 'test'
-            }
-          }
-        },
-        quantity: mockDetailedSku[inventory[0].sku].quantity
-      }
-    ])
+  it('should set the description to its value and images to an array containing the image in the entry', () => {
+    expect(lineItems[1]).toStrictEqual({
+      price_data: {
+        currency: 'USD',
+        unit_amount: 100,
+        product_data: {
+          name: 'Oranges',
+          description: 'Juicy orange fruit',
+          images: [
+            'https://images.unsplash.com/photo-1547514701-42782101795e?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=934&q=80'
+          ]
+        }
+      },
+      quantity: 2
+    })
   })
 
-  it('Properly spreads price_data from the product object into price_data', () => {
-    inventory[0].price_data = { metadata: { type: 'test' } }
-    expect(validateCartItems(inventory, { ...mockDetailedSku })).toStrictEqual([
-      {
-        price_data: {
-          currency: inventory[0].currency,
-          unit_amount: 400,
-          metadata: { type: 'test' },
-          product_data: {
-            name: inventory[0].name,
-            description: 'Yummy yellow fruit',
-            images: ['https: //www.fillmurray.com/300/300'],
-            metadata: {
-              type: 'test'
-            }
+  it("should combine the inventory's product_data with the line item's product_data", () => {
+    expect(lineItems[0]).toStrictEqual({
+      price_data: {
+        currency: 'USD',
+        unit_amount: 400,
+        product_data: {
+          name: 'Bananas',
+          description: 'Yummy yellow fruit',
+          images: [
+            'https://images.unsplash.com/photo-1571771894821-ce9b6c11b08e?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1400&q=80'
+          ],
+          metadata: {
+            availability: 'limited time',
+            type: 'fruit'
           }
-        },
-        quantity: mockDetailedSku[inventory[0].sku].quantity
-      }
-    ])
+        }
+      },
+      quantity: 1
+    })
+  })
+
+  it("should combine the entry's product_data with the line item's product_data", () => {
+    expect(lineItems[3]).toStrictEqual({
+      price_data: {
+        currency: 'USD',
+        unit_amount: 850,
+        product_data: {
+          name: 'Burger',
+          images: [
+            'https://images.unsplash.com/photo-1568901346375-23c9450c58cd?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=1502&q=80'
+          ],
+          metadata: {
+            type: 'meal',
+            // eslint-disable-next-line camelcase
+            order_id: '6753',
+            // eslint-disable-next-line camelcase
+            extra_toppings: 'jalapeños, mustard, mayo, caramelized onions'
+          }
+        }
+      },
+      quantity: 1
+    })
   })
 
   it('throws an error if product does not exist in inventory', () => {
     expect(() => {
-      validateCartItems(inventory, { sku_1234: { sku: 'sku_1234' } })
-    }).toThrow('Product sku_1234 not found!')
+      validateCartItems(inventory, {
+        // eslint-disable-next-line camelcase
+        price_icecream: {
+          id: 'price_icecream',
+          price: 2000,
+          currency: 'USD',
+          name: 'Ice Cream',
+          quantity: 1,
+          value: 2000,
+          formattedValue: '$20.00',
+          price_data: {},
+          product_data: {
+            metadata: {
+              flavor: 'rocky road'
+            }
+          }
+        }
+      })
+    }).toThrow(
+      'Invalid Cart: product with id "price_icecream" is not in your inventory.'
+    )
   })
 })
 
 describe('formatLineItems', () => {
-  it('Formats line items with price_id appropriately', () => {
-    expect(formatLineItems(mockDetailedPrice)).toStrictEqual([
-      { price: 'price_123', quantity: 5 }
-    ])
-  })
-
-  it('Formats line items with sku_id appropriately', () => {
-    expect(formatLineItems(mockDetailedSku)).toStrictEqual([
-      { price: 'sku_abc123', quantity: 3 }
+  it('Extracts the Price ID from cart entries', () => {
+    expect(formatLineItems(cartDetails)).toStrictEqual([
+      { price: 'price_bananas', quantity: 1 },
+      { price: 'price_oranges', quantity: 2 },
+      { price: 'id_donation', quantity: 1 },
+      { price: 'id_burger', quantity: 1 }
     ])
   })
 })

--- a/use-shopping-cart/utilities/serverless.test.js
+++ b/use-shopping-cart/utilities/serverless.test.js
@@ -163,7 +163,7 @@ describe('validateCartItems', () => {
     })
   })
 
-  it("should combine the entry's product_data with the line item's product_data", () => {
+  it("should pass the entry's product_data.metadata through to the line item's product_data", () => {
     expect(lineItems[3]).toStrictEqual({
       price_data: {
         currency: 'USD',


### PR DESCRIPTION
- Fixed issue with tests where `formatLineItems` wasn't working as expected.
- Allowed metadata from cart entry through to `line_items.price_data.product_data` and added tests for this.
- Fixed up the testing structure for serverless.

Let me know if we need to come up with a different plan rather than allowing metadata through or if that feature is unnecessary.