### PR TITLE
(docs): fix 404 on link "introduction" in footer

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -55,7 +55,7 @@ module.exports = {
           items: [
             {
               label: 'Introduction',
-              to: 'docs/introduction'
+              to: 'docs'
             },
             {
               label: 'Getting Started',


### PR DESCRIPTION
fix 404 on link "introduction" in footer