### PR TITLE
fixed build issues

### DIFF
--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-shopping-cart",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Shopping cart state and logic for Stripe",
   "author": "dayhaysoos",
   "license": "MIT",

--- a/use-shopping-cart/rollup.config.js
+++ b/use-shopping-cart/rollup.config.js
@@ -6,7 +6,8 @@ import replace from '@rollup/plugin-replace'
 import externals from 'rollup-plugin-node-externals'
 import visualizer from 'rollup-plugin-visualizer'
 
-import { promises as fs } from 'fs'
+import { promises as fs, existsSync } from 'fs'
+
 import path from 'path'
 
 import pkg from './package.json'
@@ -42,6 +43,23 @@ function copyTypes() {
             )
             console.error(error)
           }
+
+          try {
+            await fs.copyFile(
+              path.join(process.cwd(), 'core', 'index.d.ts'),
+              path.join(process.cwd(), 'dist', 'index.d.ts')
+            )
+          } catch (error) {
+            console.log(
+              `Unable to copy ${path.join(
+                process.cwd(),
+                'core',
+                'index.d.ts'
+              )} ${path.join(process.cwd(), 'dist', 'index.d.ts')}`
+            )
+
+            console.error(error)
+          }
         }
       }
     }
@@ -59,6 +77,13 @@ function clearDist() {
     async buildStart() {
       if (cleared) return
       cleared = true
+
+      if (existsSync(path.resolve('dist'))) {
+        console.log('dist folder exists')
+      } else {
+        console.log('dist folder unavailable, creating one...')
+        fs.mkdir('dist')
+      }
 
       try {
         await fs.rm(path.resolve('dist'), { recursive: true })


### PR DESCRIPTION
Fix for #223 

Some how `/core/index.d.ts` wasn't making it into the `dist` folder.

I just hard coded the copying of that, didn't wanna touch the `for` logic with the other file formats.

Discovered another issue where, if you delete the dist folder and run `rollup -c`, it only builds the `js` files, not typescript. 

Wrote some logic in `clearDist` where it checks if the `dist` folder exists, if it doesn't, create the folder and proceed. Seems to have worked just fine.

Need to test on a project, but would like some feedback in the mean time