### PR TITLE
remove types from path, doesn't exist

### DIFF
--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": "dayhaysoos/use-shopping-cart",
   "main": "dist/react.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "module": "dist/react.es.js",
   "jsnext:main": "dist/react.es.js",
   "unpkg": "dist/react.umd.js",

--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-shopping-cart",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Shopping cart state and logic for Stripe",
   "author": "dayhaysoos",
   "license": "MIT",


### PR DESCRIPTION
This is for #223, forgot to remove `types` from the path. That folder doesn't exist in `dist`