### PR TITLE
(fix): move usc to peerDependencies for the gatsby plugin

### DIFF
--- a/gatsby-plugin-use-shopping-cart/package.json
+++ b/gatsby-plugin-use-shopping-cart/package.json
@@ -4,10 +4,8 @@
   "description": "A plugin for use-shopping-cart to kickoff your ecommerce experience with Stripe.",
   "author": "Eric Howey <ehowey@gmail.com>",
   "main": "index.js",
-  "dependencies": {
-    "use-shopping-cart": "^3.0.3"
-  },
   "peerDependencies": {
+    "use-shopping-cart": "^3.0.0",
     "gatsby": "^3.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
- moves use-shopping-cart from the `dependencies` field to the `peerDependencies` field for the plugin