### PR TITLE
feat: update package.json exports

### DIFF
--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -27,7 +27,8 @@
     "./utilities": {
       "require": "./utilities/serverless.js",
       "node": "./utilities/serverless.js"
-    }
+    },
+    "./*": "./*.js"
   },
   "engines": {
     "node": ">=8",

--- a/use-shopping-cart/package.json
+++ b/use-shopping-cart/package.json
@@ -28,7 +28,8 @@
       "require": "./utilities/serverless.js",
       "node": "./utilities/serverless.js"
     },
-    "./*": "./*.js"
+    "./utilities/*": "./utilities/*.js",
+    "./*": "./dist/*.js"
   },
   "engines": {
     "node": ">=8",


### PR DESCRIPTION
This allows us to `import` or `require` from any arbitrary entry point without breaking the overrides above it.

Currently, for instance, it is not possible to do `import { validateCartItems } from 'use-shopping-cart/utilities/serverless'`. This is fixed by this PR.