### PR TITLE
Fix Docusaurus edit URL

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -88,7 +88,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/dayhaysoos/use-shopping-cart'
+          editUrl: 'https://github.com/dayhaysoos/use-shopping-cart/docs'
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css')


### PR DESCRIPTION
Currently the docusaurus "Edit page" button doesn't work, a "docs" is missing in URL because Docusaurus is not a the root of the GitHub repo but at "docs" folder.