### PR TITLE
(core): Add handleOpenCart API

### DIFF
--- a/use-shopping-cart/core/index.d.ts
+++ b/use-shopping-cart/core/index.d.ts
@@ -176,11 +176,14 @@ export interface CartActions {
    * @param product The product to add to the cart
    * @param count The quantity of the product to add
    */
-  addItem: (product: Product, options?: {
-    count: number
-    price_metadata?: { [propName: string]: any }
-    product_metadata?: { [propName: string]: any }
-  }) => void
+  addItem: (
+    product: Product,
+    options?: {
+      count: number
+      price_metadata?: { [propName: string]: any }
+      product_metadata?: { [propName: string]: any }
+    }
+  ) => void
 
   /**
    * Remove an item from the cart by its product ID
@@ -252,6 +255,11 @@ export interface CartActions {
    * Sets `shouldDisplayCart` to `false`.
    */
   handleCloseCart: () => void
+
+  /**
+   * Sets `shouldDisplayCart` to `true`.
+   */
+  handleOpenCart: () => void
 
   /**
    * Given a product ID, it sets `lastClicked` to that value.

--- a/use-shopping-cart/core/slice.js
+++ b/use-shopping-cart/core/slice.js
@@ -148,6 +148,9 @@ const slice = createSlice({
     handleCloseCart(state) {
       state.shouldDisplayCart = false
     },
+    handleOpenCart(state) {
+      state.shouldDisplayCart = true
+    },
     storeLastClicked(state, { payload }) {
       state.lastClicked = payload
     },

--- a/use-shopping-cart/core/slice.test.js
+++ b/use-shopping-cart/core/slice.test.js
@@ -264,6 +264,16 @@ describe('handleCloseCart', () => {
   })
 })
 
+describe('handleOpenCart', () => {
+  it('should set the cart to be displayed', () => {
+    const result = reducer(
+      { ...initialState, shouldDisplayCart: false },
+      actions.handleOpenCart()
+    )
+    expect(result.shouldDisplayCart).toBe(true)
+  })
+})
+
 describe('storeLastClicked', () => {
   it('should store id of last clicked item', () => {
     const cart = mockCart()

--- a/use-shopping-cart/react/test/index.test.js
+++ b/use-shopping-cart/react/test/index.test.js
@@ -102,6 +102,15 @@ describe('useShoppingCart()', () => {
       })
       expect(cart.current.shouldDisplayCart).toBe(false)
     })
+
+    it('is set to true by handleOpenCart()', () => {
+      act(() => {
+        cart.current.handleCartClick()
+        cart.current.handleCloseCart()
+        cart.current.handleOpenCart()
+      })
+      expect(cart.current.shouldDisplayCart).toBe(true)
+    })
   })
 
   describe('addItem()', () => {

--- a/use-shopping-cart/type-tests/react.tsx
+++ b/use-shopping-cart/type-tests/react.tsx
@@ -6,9 +6,7 @@ import * as React from 'react'
 import { CartProvider, useShoppingCart } from '../react/index'
 
 function UscWithSelector() {
-  const cart = useShoppingCart(
-    ({ totalPrice }) => ({ totalPrice })
-  )
+  const cart = useShoppingCart(({ totalPrice }) => ({ totalPrice }))
 
   cart.totalPrice
   // Can't access anything outside of totalPrice and the cart actions.
@@ -81,6 +79,7 @@ function UscActions() {
   cart.storeLastClicked('id_banana001')
   cart.handleCartHover()
   cart.handleCloseCart()
+  cart.handleOpenCart()
   cart.handleCartClick()
 
   cart.redirectToCheckout()
@@ -95,11 +94,7 @@ function UscActions() {
 function App() {
   return (
     <>
-      <CartProvider
-        cartMode="checkout-session"
-        stripe="KEY"
-        currency="USD"
-      >
+      <CartProvider cartMode="checkout-session" stripe="KEY" currency="USD">
         <UscWithSelector />
       </CartProvider>
 


### PR DESCRIPTION
Hello!

**DRAFT - Work in Progress**

Feel free to quash this request but I was working on a project recently and I specifically wanted to have an ability open the cart, and not just toggle it.

I copy-pasted the code for `handleCloseCart` and created `handleOpenCart`.

I have no idea how to test this inside of the repo - but would love to know how to do that so I can help out more in the future. Let me know if this is something that is useful and I will spend a bit more time making sure it actually works as intended.