### PR TITLE
(core): fix missing allowedCountries and billingAddressCollection for checkoutSingleItem

### DIFF
--- a/use-shopping-cart/core/middleware/stripe.js
+++ b/use-shopping-cart/core/middleware/stripe.js
@@ -78,7 +78,15 @@ export const handleStripe = (store) => (next) => async (action) => {
         mode: cart.mode,
         successUrl: cart.successUrl,
         cancelUrl: cart.cancelUrl,
-        lineItems: [{ price: productId, quantity: 1 }]
+        lineItems: [{ price: productId, quantity: 1 }],
+        billingAddressCollection: cart.billingAddressCollection
+          ? 'required'
+          : 'auto'
+      }
+      if (cart.allowedCountries?.length) {
+        options.shippingAddressCollection = {
+          allowedCountries: cart.allowedCountries
+        }
       }
       return stripe.redirectToCheckout(options)
     } else {


### PR DESCRIPTION
`checkoutSingleItem` is not properly passing the values for `allowedCountries` and `billingAddressCollection` to Stripe.

This is my attempt at what I think a fix should be.  As stated in my other PR I am not quite sure how to test this library in abstraction, but I _think_ this should be the fix required to get it working, or very close to the fix.