### PR TITLE
feat: update checkoutSingleItem to support three types of input 

### DIFF
--- a/use-shopping-cart/core/middleware/stripe.js
+++ b/use-shopping-cart/core/middleware/stripe.js
@@ -73,12 +73,11 @@ export const handleStripe = (store) => (next) => async (action) => {
     const stripe = initializeStripe(stripePublicKey)
 
     if (cart.cartMode === 'client-only') {
-      const productId = action.payload.productId
       const options = {
         mode: cart.mode,
         successUrl: cart.successUrl,
         cancelUrl: cart.cancelUrl,
-        lineItems: [{ price: productId, quantity: 1 }]
+        ...action.payload.cartItems
       }
       return stripe.redirectToCheckout(options)
     } else {

--- a/use-shopping-cart/core/slice.js
+++ b/use-shopping-cart/core/slice.js
@@ -167,9 +167,52 @@ slice.actions.redirectToCheckout = (sessionId) => ({
   type: 'cart/redirectToCheckout',
   payload: sessionId
 })
-slice.actions.checkoutSingleItem = (productId) => ({
-  type: 'cart/checkoutSingleItem',
-  payload: productId
-})
+slice.actions.checkoutSingleItem = (itemsOrPriceId) => {
+  const quantity = itemsOrPriceId.quantity || 1
+
+  const cartItems = (() => {
+    if (typeof itemsOrPriceId === 'string') {
+      return {
+        lineItems: [
+          {
+            price: itemsOrPriceId,
+            quantity
+          }
+        ]
+      }
+    }
+    if (Object.prototype.hasOwnProperty.call(itemsOrPriceId, 'price')) {
+      return {
+        lineItems: [
+          {
+            price: itemsOrPriceId.price,
+            quantity
+          }
+        ]
+      }
+    }
+    /**
+     * Backward compatibility (SKU)
+     */
+    if (Object.prototype.hasOwnProperty.call(itemsOrPriceId, 'sku')) {
+      return {
+        items: [
+          {
+            sku: itemsOrPriceId.sku,
+            quantity
+          }
+        ]
+      }
+    }
+    return []
+  })()
+
+  return {
+    type: 'cart/checkoutSingleItem',
+    payload: {
+      cartItems
+    }
+  }
+}
 
 export const { reducer, actions } = slice

--- a/use-shopping-cart/core/slice.test.js
+++ b/use-shopping-cart/core/slice.test.js
@@ -280,3 +280,104 @@ describe('storeLastClicked', () => {
     expect(result.lastClicked).toEqual(product.id)
   })
 })
+
+describe('checkoutSingleItem', () => {
+  it('should return lineItems when given string', () => {
+    const product = mockProduct()
+    expect(actions.checkoutSingleItem(product.id)).toEqual({
+      payload: {
+        cartItems: {
+          lineItems: [
+            {
+              price: product.id,
+              quantity: 1
+            }
+          ]
+        }
+      },
+      type: 'cart/checkoutSingleItem'
+    })
+  })
+  it('should return lineItems when given price object', () => {
+    const product = mockProduct()
+    expect(
+      actions.checkoutSingleItem({
+        price: product.id
+      })
+    ).toEqual({
+      payload: {
+        cartItems: {
+          lineItems: [
+            {
+              price: product.id,
+              quantity: 1
+            }
+          ]
+        }
+      },
+      type: 'cart/checkoutSingleItem'
+    })
+  })
+  it('should return lineItems when given price object with quantity', () => {
+    const product = mockProduct()
+    expect(
+      actions.checkoutSingleItem({
+        price: product.id,
+        quantity: 2
+      })
+    ).toEqual({
+      payload: {
+        cartItems: {
+          lineItems: [
+            {
+              price: product.id,
+              quantity: 2
+            }
+          ]
+        }
+      },
+      type: 'cart/checkoutSingleItem'
+    })
+  })
+  it('should return items when given sku object', () => {
+    const product = mockProduct()
+    expect(
+      actions.checkoutSingleItem({
+        sku: product.id
+      })
+    ).toEqual({
+      payload: {
+        cartItems: {
+          items: [
+            {
+              sku: product.id,
+              quantity: 1
+            }
+          ]
+        }
+      },
+      type: 'cart/checkoutSingleItem'
+    })
+  })
+  it('should return items when given sku object with quantity', () => {
+    const product = mockProduct()
+    expect(
+      actions.checkoutSingleItem({
+        sku: product.id,
+        quantity: 2
+      })
+    ).toEqual({
+      payload: {
+        cartItems: {
+          items: [
+            {
+              sku: product.id,
+              quantity: 2
+            }
+          ]
+        }
+      },
+      type: 'cart/checkoutSingleItem'
+    })
+  })
+})

--- a/use-shopping-cart/react/test/index.test.js
+++ b/use-shopping-cart/react/test/index.test.js
@@ -599,46 +599,114 @@ describe('redirectToCheckout()', () => {
     })
   })
 
-  // TODO : check on bug for sending product.id as price in stripe-middleware?
-  describe.skip('checkoutSingleItem()', () => {
+  describe('checkoutSingleItem()', () => {
     const product = mockProduct()
 
-    it('should send the formatted item with no quantity parameter', async () => {
-      await act(async () => {
-        await cart.current.checkoutSingleItem({
-          sku: product.id
+    describe('priceId', () => {
+      it('should send the formatted item', async () => {
+        await act(async () => {
+          await cart.current.checkoutSingleItem(product.id)
         })
-      })
 
-      const expectedCheckoutOptions = expect.objectContaining({
-        lineItems: {
-          price: product.id,
-          quantity: 1
-        }
-      })
+        const expectedCheckoutOptions = expect.objectContaining({
+          lineItems: [
+            {
+              price: product.id,
+              quantity: 1
+            }
+          ]
+        })
 
-      expect(stripeMock.redirectToCheckout).toHaveBeenCalledWith(
-        expectedCheckoutOptions
-      )
+        expect(stripeMock.redirectToCheckout).toHaveBeenCalledWith(
+          expectedCheckoutOptions
+        )
+      })
     })
-
-    it('should send the formatted item with a custom quantity parameter', async () => {
-      await act(async () => {
-        await cart.current.checkoutSingleItem({
-          sku: product.id,
-          quantity: 47
+    describe('price(object)', () => {
+      it('should send the formatted item with no quantity parameter', async () => {
+        await act(async () => {
+          await cart.current.checkoutSingleItem({
+            price: product.id
+          })
         })
+
+        const expectedCheckoutOptions = expect.objectContaining({
+          lineItems: [
+            {
+              price: product.id,
+              quantity: 1
+            }
+          ]
+        })
+
+        expect(stripeMock.redirectToCheckout).toHaveBeenCalledWith(
+          expectedCheckoutOptions
+        )
       })
 
-      const expectedCheckoutOptions = expect.objectContaining({
-        lineItems: {
-          sku: product.id,
-          quantity: 47
-        }
+      it('should send the formatted item with a custom quantity parameter', async () => {
+        await act(async () => {
+          await cart.current.checkoutSingleItem({
+            price: product.id,
+            quantity: 47
+          })
+        })
+
+        const expectedCheckoutOptions = expect.objectContaining({
+          lineItems: [
+            {
+              price: product.id,
+              quantity: 47
+            }
+          ]
+        })
+        expect(stripeMock.redirectToCheckout).toHaveBeenCalledWith(
+          expectedCheckoutOptions
+        )
       })
-      expect(stripeMock.redirectToCheckout).toHaveBeenCalledWith(
-        expectedCheckoutOptions
-      )
+    })
+    describe('sku (Deprecated)', () => {
+      it('should send the formatted item with no quantity parameter', async () => {
+        await act(async () => {
+          await cart.current.checkoutSingleItem({
+            sku: product.id
+          })
+        })
+
+        const expectedCheckoutOptions = expect.objectContaining({
+          items: [
+            {
+              sku: product.id,
+              quantity: 1
+            }
+          ]
+        })
+
+        expect(stripeMock.redirectToCheckout).toHaveBeenCalledWith(
+          expectedCheckoutOptions
+        )
+      })
+
+      it('should send the formatted item with a custom quantity parameter', async () => {
+        await act(async () => {
+          await cart.current.checkoutSingleItem({
+            sku: product.id,
+            quantity: 47
+          })
+        })
+
+        const expectedCheckoutOptions = expect.objectContaining({
+          items: [
+            {
+              sku: product.id,
+              quantity: 47
+            }
+          ]
+        })
+        expect(stripeMock.redirectToCheckout).toHaveBeenCalledWith(
+          expectedCheckoutOptions
+        )
+      })
     })
 
     describe('with a checkout-session cartMode', () => {

--- a/use-shopping-cart/react/test/index.test.js
+++ b/use-shopping-cart/react/test/index.test.js
@@ -711,11 +711,11 @@ describe('redirectToCheckout()', () => {
 
     describe('with a checkout-session cartMode', () => {
       beforeEach(() => {
-        cart = reload({ mode: 'checkout-session' })
+        cart = reload({ cartMode: 'checkout-session' })
       })
 
       it('throws an error', async () => {
-        expect(
+        await expect(
           cart.current.checkoutSingleItem({ sku: product.id })
         ).rejects.toThrow(PropertyValueError)
       })


### PR DESCRIPTION
I found the TODO comment in this file.

> // TODO : check on bug for sending product.id as price in stripe-middleware?
https://github.com/dayhaysoos/use-shopping-cart/blob/master/use-shopping-cart/react/test/index.test.js#L602

And I probably found the way to resolve the issue, so I'd made this Pull Request.

# Usage
## Provide a price id as string

```js
checkoutSingleItem('price_xxx')

{
  ...,
  lineItems: [{
    price: 'price_xxx',
    quantity: 1
  }]
}
```

## Provide a object props includes a price id (and quantity)

```js
checkoutSingleItem({
  price: 'price_xxx',
  quantity: 2
})

{
  ...,
  lineItems: [{
    price: 'price_xxx',
    quantity: 2
  }]
}
```


## Provide a object props includes a sku id (and quantity)

```js
checkoutSingleItem({
  sku: 'sku_xxx',
  quantity: 2
})

{
  ...,
  items: [{
    sku: 'price_xxx',
    quantity: 2
  }]
}
```

==

We can check the entire behavior in this file.

https://github.com/hideokamoto-stripe/use-shopping-cart/blob/feat/checkout-single-item/use-shopping-cart/react/test/index.test.js#L602-L724

Thanks!