### PR TITLE
Add funding link to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,11 @@
     "all-contributors-cli": "^6.20.0",
     "typescript": "^4.4.3",
     "webpack-dev-server": "3.11.1"
-  }
+  },
+  "funding": [
+    {
+      "type": "sponsors",
+      "url": "https://github.com/sponsors/dayhaysoos"
+    }
+  ]
 }


### PR DESCRIPTION
👋 @dayhaysoos 

This PR adds a [`funding`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#funding) field to the `package.json`. With this a user can run `npm fund use-shopping-cart` and be directed to your GitHub Sponsors page. If [`npm fund`](https://docs.npmjs.com/cli/v8/commands/npm-fund) is run in any project where `use-shopping-cart` is a dependancy they will receive information on how to fund it!

