### PR TITLE
fix typos getting-started-serverless

### DIFF
--- a/docs/docs/welcome/getting-started-serverless.mdx
+++ b/docs/docs/welcome/getting-started-serverless.mdx
@@ -46,9 +46,9 @@ The hook `useShoppingCart()` provides several utilities and pieces of data for y
 
 ### Serverless implementation
 
-If you're data source isn't coming from Stripe's dashboard, you can still make products and process payments.
+If your data source isn't coming from Stripe's dashboard, you can still make products and process payments.
 
-You're product data should look like this:
+Your product data should look like this:
 
 ```js
 const productData = [


### PR DESCRIPTION
Fixed docs, "your" instead of "you're".