### PR TITLE
Removes reference to secret key in Getting Started Client Only docs

### DIFF
--- a/docs/docs/welcome/getting-started-client-mode.mdx
+++ b/docs/docs/welcome/getting-started-client-mode.mdx
@@ -13,7 +13,7 @@ or
 yarn add use-shopping-cart
 ```
 
-The package needs to be configured with your account's secret key, which is available in the [Stripe Dashboard](https://dashboard.stripe.com/apikeys). Require it with the key's value.
+The package needs to be configured with your account's publishable key, which is available in the [Stripe Dashboard](https://dashboard.stripe.com/apikeys). Require it with the key's value.
 
 At the root level of your app, wrap your root component in the `<CartProvider />`
 


### PR DESCRIPTION
Updates the documentation to remove reference to the secret key in the Getting Started guide for Client Only Mode

![image](https://user-images.githubusercontent.com/64803272/215811540-7960fd98-6a6f-438d-9bdc-af5bc5b5221a.png)
