### PR TITLE
Fixes "Edit this page" link in docs

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -88,7 +88,8 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/dayhaysoos/use-shopping-cart'
+          editUrl:
+            'https://github.com/dayhaysoos/use-shopping-cart/edit/master/docs/'
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css')


### PR DESCRIPTION
This PR fixes the "Edit this page" link at the bottom of the docs. I had a look at the docusaurus docs to see how to fix this. 

For someone without a fork of the repository, it will look like this when they click to edit the docs:

<img width="1277" alt="image" src="https://user-images.githubusercontent.com/64803272/219968042-7a9189b4-d6a6-4348-ab16-5358069f3e0f.png">

If they already have a fork of the application, it will take them to edit the page on their fork:

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/64803272/219970096-96264f44-62eb-4b3d-b4c6-8738d38aef3d.png">

It then makes a commit in your fork and takes you to the screen to open a pull request straight away:

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/64803272/219970387-1d82c7b2-3db7-45b4-b2c6-a521b88f5052.png">

I've tested this locally and seems to be working well. 
