### PR TITLE
fix(doc): fix get started link on Intro page

### DIFF
--- a/docs/docs/welcome/introduction.mdx
+++ b/docs/docs/welcome/introduction.mdx
@@ -24,4 +24,4 @@ Shopping Cart State and Logic for Stripe in React
 
 <br />
 
-[Get started now!](/docs/getting-started)
+[Get started now!](/docs/welcome/getting-started)


### PR DESCRIPTION
This PR aims to fix the "Get started now!" link from the Introduction page, which currently is leading us to a 404 page:
![image](https://user-images.githubusercontent.com/8760873/221393809-a593cd5a-1181-4ea4-9fef-f38d62f14704.png)


So I've just added the `welcome` path and now it leads to the right get started page 🎉 
![image](https://user-images.githubusercontent.com/8760873/221393859-a76788c8-0067-4266-b3d4-bf623cfe55a4.png)

