### PR TITLE
Fix documentation example error for checkout session mode

### DIFF
--- a/docs/docs/usage/components/CartProvider.mdx
+++ b/docs/docs/usage/components/CartProvider.mdx
@@ -21,7 +21,6 @@ const stripeKey = process.env.YOUR_STRIPE_PUBLIC_KEY
 
 ReactDOM.render(
   <CartProvider
-    mode="payment"
     cartMode="checkout-session"
     stripe={stripeKey}
     currency="USD"


### PR DESCRIPTION
Currently, the checkout session mode example has a type error in the documentation, if you set `cartMode="checkout-session"` then `mode="payment"` does not exist in type

<img width="591" alt="Screenshot 2023-03-25 at 19 12 02" src="https://user-images.githubusercontent.com/22602440/227749928-e7b6b3b0-00c7-4a58-b9b9-ae9411924ed7.png">

That behavior is expected since the mode and other parameters are defined in the backend and the CheckoutSession mode doesn't  actually include the mode

https://github.com/dayhaysoos/use-shopping-cart/blob/f3bd4736916c4bf97c0c7cd8af6a25d4a8ab87d8/use-shopping-cart/core/index.d.ts#L58-L63

So the is only remove that line from the example