### PR TITLE
fix ts error - no declartion file for utilities fixes #324

### DIFF
--- a/use-shopping-cart/utilities/index.d.ts
+++ b/use-shopping-cart/utilities/index.d.ts
@@ -1,0 +1,1 @@
+export * from './serverless'


### PR DESCRIPTION
Since the [`utilities/index.js`](https://github.com/dayhaysoos/use-shopping-cart/blob/master/use-shopping-cart/utilities/index.js) only exports the `serverless.js`, TypeScripts expects a `index.d.ts` too.

A simple `index.d.ts` which exports the `serverless.d.ts` will do it.
