### PR TITLE
Harden cart validation and persistence

### DIFF
--- a/use-shopping-cart/core/Entry.test.ts
+++ b/use-shopping-cart/core/Entry.test.ts
@@ -60,6 +60,55 @@ describe('getProductId', () => {
     expect(typeof id).toBe('string')
     expect(id.length).toBeGreaterThan(0)
   })
+
+  it('does not mutate product when generating ID', () => {
+    const product: Product = {
+      name: 'Test',
+      price: 100,
+      currency: 'USD'
+    }
+
+    getProductId(product)
+
+    expect(product).not.toHaveProperty('id')
+  })
+
+  it('falls back to custom UUID when crypto.randomUUID is unavailable', () => {
+    const product: Product = {
+      name: 'Test',
+      price: 100,
+      currency: 'USD'
+    }
+
+    const originalCrypto = globalThis.crypto
+    Object.defineProperty(globalThis, 'crypto', {
+      value: undefined,
+      configurable: true
+    })
+
+    const id = getProductId(product)
+
+    Object.defineProperty(globalThis, 'crypto', {
+      value: originalCrypto,
+      configurable: true
+    })
+
+    expect(id).toBeTruthy()
+    expect(typeof id).toBe('string')
+  })
+
+  it('returns consistent generated IDs for the same product reference', () => {
+    const product: Product = {
+      name: 'Test',
+      price: 100,
+      currency: 'USD'
+    }
+
+    const firstId = getProductId(product)
+    const secondId = getProductId(product)
+
+    expect(firstId).toBe(secondId)
+  })
 })
 
 describe('createCartEntry', () => {

--- a/use-shopping-cart/core/Entry.ts
+++ b/use-shopping-cart/core/Entry.ts
@@ -17,10 +17,10 @@ function generateUUID(): string {
   })
 }
 
+const generatedIdCache = new WeakMap<object, string>()
+
 /**
  * Extract the ID from a product (or generate one if missing).
- * If a UUID is generated, it is attached to the product object
- * to ensure consistent identification on subsequent calls.
  */
 export function getProductId(product: Product): string {
   const existingId =
@@ -31,9 +31,11 @@ export function getProductId(product: Product): string {
 
   if (existingId) return existingId
 
-  // Generate and attach ID to product for consistency
+  const cachedId = generatedIdCache.get(product as object)
+  if (cachedId) return cachedId
+
   const generatedId = generateUUID()
-  ;(product as { id?: string }).id = generatedId
+  generatedIdCache.set(product as object, generatedId)
   return generatedId
 }
 

--- a/use-shopping-cart/core/ShoppingCart.test.ts
+++ b/use-shopping-cart/core/ShoppingCart.test.ts
@@ -131,7 +131,9 @@ describe('ShoppingCart', () => {
           },
           cartCount: 5,
           totalPrice: 1000,
-          formattedTotalPrice: '$10.00'
+          formattedTotalPrice: '$10.00',
+          currency: 'EUR',
+          language: 'de-DE'
         })
       )
 
@@ -145,6 +147,8 @@ describe('ShoppingCart', () => {
       expect(state.cartCount).toBe(5)
       expect(state.totalPrice).toBe(1000)
       expect(state.cartDetails['item-1']).toBeDefined()
+      expect(state.currency).toBe('EUR')
+      expect(state.language).toBe('de-DE')
     })
 
     it('handles missing storage gracefully', () => {

--- a/use-shopping-cart/core/ShoppingCart.ts
+++ b/use-shopping-cart/core/ShoppingCart.ts
@@ -186,9 +186,13 @@ export class ShoppingCart {
         }
 
         const nextCurrency =
-          typeof currency === 'string' ? currency : this._state.currency
+          typeof currency === 'string' && currency.length > 0
+            ? currency
+            : this._state.currency
         const nextLanguage =
-          typeof language === 'string' ? language : this._state.language
+          typeof language === 'string' && language.length > 0
+            ? language
+            : this._state.language
 
         // Recalculate totals from validated entries
         const { totalPrice, cartCount } = calculateTotals(validatedCartDetails)

--- a/use-shopping-cart/core/ShoppingCart.ts
+++ b/use-shopping-cart/core/ShoppingCart.ts
@@ -154,9 +154,13 @@ export class ShoppingCart {
     return (
       typeof e.id === 'string' &&
       typeof e.price === 'number' &&
+      Number.isFinite(e.price) &&
       typeof e.quantity === 'number' &&
+      Number.isFinite(e.quantity) &&
+      Number.isInteger(e.quantity) &&
       e.quantity > 0 &&
       typeof e.value === 'number' &&
+      Number.isFinite(e.value) &&
       typeof e.name === 'string' &&
       typeof e.currency === 'string'
     )
@@ -167,7 +171,7 @@ export class ShoppingCart {
       const parsed = JSON.parse(stored)
 
       // Only restore specific fields
-      const { cartDetails } = parsed
+      const { cartDetails, currency, language } = parsed
 
       if (cartDetails && typeof cartDetails === 'object') {
         // Validate each cart entry before loading
@@ -181,18 +185,25 @@ export class ShoppingCart {
           }
         }
 
+        const nextCurrency =
+          typeof currency === 'string' ? currency : this._state.currency
+        const nextLanguage =
+          typeof language === 'string' ? language : this._state.language
+
         // Recalculate totals from validated entries
         const { totalPrice, cartCount } = calculateTotals(validatedCartDetails)
 
         this._state = {
           ...this._state,
+          currency: nextCurrency,
+          language: nextLanguage,
           cartDetails: validatedCartDetails,
           cartCount,
           totalPrice,
           formattedTotalPrice: calculateFormattedTotalPrice(
             totalPrice,
-            this._state.currency,
-            this._state.language
+            nextCurrency,
+            nextLanguage
           )
         }
         // Notify subscribers so React components re-render with loaded cart data
@@ -214,7 +225,9 @@ export class ShoppingCart {
         cartDetails: this._state.cartDetails,
         cartCount: this._state.cartCount,
         totalPrice: this._state.totalPrice,
-        formattedTotalPrice: this._state.formattedTotalPrice
+        formattedTotalPrice: this._state.formattedTotalPrice,
+        currency: this._state.currency,
+        language: this._state.language
       }
 
       this._storage.setItem(this._persistKey, JSON.stringify(toPersist))

--- a/use-shopping-cart/core/storage.test.ts
+++ b/use-shopping-cart/core/storage.test.ts
@@ -219,7 +219,9 @@ describe('ShoppingCart with async storage', () => {
           }
         },
         cartCount: 3,
-        totalPrice: 1500
+        totalPrice: 1500,
+        currency: 'EUR',
+        language: 'fr-FR'
       })
     )
 
@@ -234,5 +236,7 @@ describe('ShoppingCart with async storage', () => {
     // Should have loaded from storage
     expect(state.cartDetails['stored-item']).toBeDefined()
     expect(state.cartCount).toBe(3)
+    expect(state.currency).toBe('EUR')
+    expect(state.language).toBe('fr-FR')
   })
 })

--- a/use-shopping-cart/core/validation.test.ts
+++ b/use-shopping-cart/core/validation.test.ts
@@ -10,7 +10,17 @@ import {
 describe('validateCount', () => {
   it('throws on non-number', () => {
     expect(() => validateCount('5', 'addItem')).toThrow(ValidationError)
-    expect(() => validateCount('5', 'addItem')).toThrow('must be a number')
+    expect(() => validateCount('5', 'addItem')).toThrow('finite number')
+  })
+
+  it('throws on non-integer', () => {
+    expect(() => validateCount(1.5, 'addItem')).toThrow(ValidationError)
+    expect(() => validateCount(1.5, 'addItem')).toThrow('integer')
+  })
+
+  it('throws on infinite', () => {
+    expect(() => validateCount(Infinity, 'addItem')).toThrow(ValidationError)
+    expect(() => validateCount(Infinity, 'addItem')).toThrow('finite number')
   })
 
   it('throws on zero', () => {
@@ -40,7 +50,23 @@ describe('validateQuantity', () => {
       ValidationError
     )
     expect(() => validateQuantity('5', 'setItemQuantity')).toThrow(
-      'must be a number'
+      'finite number'
+    )
+  })
+
+  it('throws on non-integer', () => {
+    expect(() => validateQuantity(2.5, 'setItemQuantity')).toThrow(
+      ValidationError
+    )
+    expect(() => validateQuantity(2.5, 'setItemQuantity')).toThrow('integer')
+  })
+
+  it('throws on infinite', () => {
+    expect(() => validateQuantity(Infinity, 'setItemQuantity')).toThrow(
+      ValidationError
+    )
+    expect(() => validateQuantity(Infinity, 'setItemQuantity')).toThrow(
+      'finite number'
     )
   })
 

--- a/use-shopping-cart/core/validation.ts
+++ b/use-shopping-cart/core/validation.ts
@@ -17,10 +17,16 @@ export class ValidationError extends Error {
 }
 
 export function validateCount(count: unknown, actionName: string): void {
-  if (typeof count !== 'number') {
-    const error = `Invalid count in ${actionName}: count must be a number. The current type is ${typeOf(
+  if (typeof count !== 'number' || !Number.isFinite(count)) {
+    const error = `Invalid count in ${actionName}: count must be a finite number. The current type is ${typeOf(
       count
     )}.`
+    console.warn(error)
+    throw new ValidationError(error)
+  }
+
+  if (!Number.isInteger(count)) {
+    const error = `Invalid count in ${actionName}: count must be an integer. The current value is ${count}.`
     console.warn(error)
     throw new ValidationError(error)
   }
@@ -33,10 +39,16 @@ export function validateCount(count: unknown, actionName: string): void {
 }
 
 export function validateQuantity(quantity: unknown, actionName: string): void {
-  if (typeof quantity !== 'number') {
-    const error = `Invalid quantity in ${actionName}: quantity must be a number. The current type is ${typeOf(
+  if (typeof quantity !== 'number' || !Number.isFinite(quantity)) {
+    const error = `Invalid quantity in ${actionName}: quantity must be a finite number. The current type is ${typeOf(
       quantity
     )}.`
+    console.warn(error)
+    throw new ValidationError(error)
+  }
+
+  if (!Number.isInteger(quantity)) {
+    const error = `Invalid quantity in ${actionName}: quantity must be an integer. The current value is ${quantity}.`
     console.warn(error)
     throw new ValidationError(error)
   }

--- a/use-shopping-cart/react/useCartActions.test.jsx
+++ b/use-shopping-cart/react/useCartActions.test.jsx
@@ -25,7 +25,9 @@ beforeAll(() => {
     if (
       typeof args[0] === 'string' &&
       (args[0].includes('Invalid product ID') ||
-        args[0].includes('Invalid count used'))
+        args[0].includes('Invalid count used') ||
+        args[0].includes('Invalid count in') ||
+        args[0].includes('Invalid quantity in'))
     ) {
       return
     }
@@ -99,6 +101,104 @@ describe('useCartActions', () => {
       })
 
       expect(result.current.addItemState.error).toBe('Product data is required')
+    })
+
+    test('should reject invalid JSON product data', async () => {
+      const { result } = renderHook(() => useCartActions(), { wrapper })
+
+      const formData = new FormData()
+      formData.append('product', '{broken')
+
+      await act(async () => {
+        await result.current.addToCartAction(formData)
+      })
+
+      await waitFor(() => {
+        expect(result.current.addItemState.status).toBe('error')
+      })
+
+      expect(result.current.addItemState.error).toBe(
+        'Product data must be valid JSON'
+      )
+    })
+
+    test('should reject oversized product data', async () => {
+      const { result } = renderHook(() => useCartActions(), { wrapper })
+
+      const formData = new FormData()
+      formData.append('product', 'x'.repeat(60_000))
+
+      await act(async () => {
+        await result.current.addToCartAction(formData)
+      })
+
+      await waitFor(() => {
+        expect(result.current.addItemState.status).toBe('error')
+      })
+
+      expect(result.current.addItemState.error).toBe(
+        'Product data is too large'
+      )
+    })
+
+    test('should reject non-integer count', async () => {
+      const { result } = renderHook(() => useCartActions(), { wrapper })
+
+      const formData = new FormData()
+      formData.append('product', JSON.stringify(mockProduct))
+      formData.append('count', '1.5')
+
+      await act(async () => {
+        await result.current.addToCartAction(formData)
+      })
+
+      await waitFor(() => {
+        expect(result.current.addItemState.status).toBe('error')
+      })
+
+      expect(result.current.addItemState.error).toBe(
+        'count must be a positive integer'
+      )
+    })
+
+    test('should reject infinite count', async () => {
+      const { result } = renderHook(() => useCartActions(), { wrapper })
+
+      const formData = new FormData()
+      formData.append('product', JSON.stringify(mockProduct))
+      formData.append('count', 'Infinity')
+
+      await act(async () => {
+        await result.current.addToCartAction(formData)
+      })
+
+      await waitFor(() => {
+        expect(result.current.addItemState.status).toBe('error')
+      })
+
+      expect(result.current.addItemState.error).toBe(
+        'count must be a positive integer'
+      )
+    })
+
+    test('should reject negative count', async () => {
+      const { result } = renderHook(() => useCartActions(), { wrapper })
+
+      const formData = new FormData()
+      formData.append('product', JSON.stringify(mockProduct))
+      formData.append('count', '-2')
+
+      await act(async () => {
+        await result.current.addToCartAction(formData)
+      })
+
+      await waitFor(() => {
+        expect(result.current.addItemState.status).toBe('error')
+      })
+
+      expect(result.current.addItemState.error).toBe(
+        'count must be a positive integer'
+      )
     })
 
     test('should default count to 1 if not provided', async () => {
@@ -234,7 +334,7 @@ describe('useCartActions', () => {
       })
 
       expect(result.current.updateQuantityState.error).toBe(
-        'Quantity must be a valid number'
+        'quantity must be a non-negative integer'
       )
     })
 
@@ -254,7 +354,47 @@ describe('useCartActions', () => {
       })
 
       expect(result.current.updateQuantityState.error).toBe(
-        'Quantity must be a valid number'
+        'quantity must be a non-negative integer'
+      )
+    })
+
+    test('should reject non-integer quantity', async () => {
+      const { result } = renderHook(() => useCartActions(), { wrapper })
+
+      const formData = new FormData()
+      formData.append('itemId', 'test_id')
+      formData.append('quantity', '1.25')
+
+      await act(async () => {
+        await result.current.updateQuantityAction(formData)
+      })
+
+      await waitFor(() => {
+        expect(result.current.updateQuantityState.status).toBe('error')
+      })
+
+      expect(result.current.updateQuantityState.error).toBe(
+        'quantity must be a non-negative integer'
+      )
+    })
+
+    test('should reject infinite quantity', async () => {
+      const { result } = renderHook(() => useCartActions(), { wrapper })
+
+      const formData = new FormData()
+      formData.append('itemId', 'test_id')
+      formData.append('quantity', 'Infinity')
+
+      await act(async () => {
+        await result.current.updateQuantityAction(formData)
+      })
+
+      await waitFor(() => {
+        expect(result.current.updateQuantityState.status).toBe('error')
+      })
+
+      expect(result.current.updateQuantityState.error).toBe(
+        'quantity must be a non-negative integer'
       )
     })
   })
@@ -336,6 +476,26 @@ describe('useCartActions', () => {
         'Item ID is required'
       )
     })
+
+    test('should reject invalid count', async () => {
+      const { result } = renderHook(() => useCartActions(), { wrapper })
+
+      const formData = new FormData()
+      formData.append('itemId', 'test_id')
+      formData.append('count', '0')
+
+      await act(async () => {
+        await result.current.incrementItemAction(formData)
+      })
+
+      await waitFor(() => {
+        expect(result.current.incrementItemState.status).toBe('error')
+      })
+
+      expect(result.current.incrementItemState.error).toBe(
+        'count must be a positive integer'
+      )
+    })
   })
 
   describe('decrementItemAction', () => {
@@ -385,6 +545,26 @@ describe('useCartActions', () => {
 
       expect(result.current.decrementItemState.error).toBe(
         'Item ID is required'
+      )
+    })
+
+    test('should reject invalid count', async () => {
+      const { result } = renderHook(() => useCartActions(), { wrapper })
+
+      const formData = new FormData()
+      formData.append('itemId', 'test_id')
+      formData.append('count', '-1')
+
+      await act(async () => {
+        await result.current.decrementItemAction(formData)
+      })
+
+      await waitFor(() => {
+        expect(result.current.decrementItemState.status).toBe('error')
+      })
+
+      expect(result.current.decrementItemState.error).toBe(
+        'count must be a positive integer'
       )
     })
   })

--- a/use-shopping-cart/react/useCartActions.tsx
+++ b/use-shopping-cart/react/useCartActions.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from 'react'
 import { useShoppingCart } from './useShoppingCart'
 import { validateProduct } from '../core/validation'
+import { getProductId } from '../core/Entry'
 
 interface ActionState<T = null> {
   status: 'idle' | 'success' | 'error'
@@ -134,12 +135,7 @@ export function useCartActions() {
         return {
           status: 'success',
           error: null,
-          productId:
-            safeProduct.id ||
-            safeProduct.price_id ||
-            safeProduct.sku_id ||
-            safeProduct.sku ||
-            null
+          productId: getProductId(safeProduct)
         }
       } catch (error) {
         return {
@@ -208,16 +204,7 @@ export function useCartActions() {
 
           const quantity = parseNonNegativeInteger(quantityStr, 'quantity')
 
-          if (quantity === null) {
-            return {
-              status: 'error',
-              error: 'Quantity is required',
-              itemId: null,
-              quantity: null
-            }
-          }
-
-          cart.setItemQuantity(itemId, quantity)
+          cart.setItemQuantity(itemId, quantity!)
 
           return { status: 'success', error: null, itemId, quantity }
         } catch (error) {

--- a/use-shopping-cart/react/useCartActions.tsx
+++ b/use-shopping-cart/react/useCartActions.tsx
@@ -12,6 +12,8 @@ interface ActionState<T = null> {
   quantity?: number | null
 }
 
+const MAX_PRODUCT_JSON_LENGTH = 50_000
+
 type AddItemState = ActionState & { productId: string | null }
 type ItemState = ActionState & { itemId: string | null }
 type QuantityState = ActionState & {
@@ -24,6 +26,40 @@ function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message
   if (typeof error === 'string') return error
   return 'An unknown error occurred'
+}
+
+function parsePositiveInteger(
+  value: FormDataEntryValue | null,
+  fieldName: string
+): number | null {
+  if (value === null) return null
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string`)
+  }
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${fieldName} must be a positive integer`)
+  }
+
+  return parsed
+}
+
+function parseNonNegativeInteger(
+  value: FormDataEntryValue | null,
+  fieldName: string
+): number | null {
+  if (value === null) return null
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a string`)
+  }
+
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${fieldName} must be a non-negative integer`)
+  }
+
+  return parsed
 }
 
 /**
@@ -67,18 +103,43 @@ export function useCartActions() {
           }
         }
 
-        const product = JSON.parse(productJSON)
-        validateProduct(product)
-        const count =
-          countStr && typeof countStr === 'string' ? parseInt(countStr, 10) : 1
+        if (productJSON.length > MAX_PRODUCT_JSON_LENGTH) {
+          return {
+            status: 'error',
+            error: 'Product data is too large',
+            productId: null
+          }
+        }
 
-        cart.addItem(product, { count })
+        let product: unknown
+        try {
+          product = JSON.parse(productJSON)
+        } catch (error) {
+          if (error instanceof SyntaxError) {
+            return {
+              status: 'error',
+              error: 'Product data must be valid JSON',
+              productId: null
+            }
+          }
+          throw error
+        }
+
+        validateProduct(product)
+        const count = parsePositiveInteger(countStr, 'count') ?? 1
+
+        const safeProduct = product as Parameters<typeof cart.addItem>[0]
+        cart.addItem(safeProduct, { count })
 
         return {
           status: 'success',
           error: null,
           productId:
-            product.id || product.price_id || product.sku_id || product.sku
+            safeProduct.id ||
+            safeProduct.price_id ||
+            safeProduct.sku_id ||
+            safeProduct.sku ||
+            null
         }
       } catch (error) {
         return {
@@ -145,12 +206,12 @@ export function useCartActions() {
             }
           }
 
-          const quantity = parseInt(quantityStr, 10)
+          const quantity = parseNonNegativeInteger(quantityStr, 'quantity')
 
-          if (isNaN(quantity) || quantity < 0) {
+          if (quantity === null) {
             return {
               status: 'error',
-              error: 'Quantity must be a valid number',
+              error: 'Quantity is required',
               itemId: null,
               quantity: null
             }
@@ -206,10 +267,7 @@ export function useCartActions() {
             }
           }
 
-          const count =
-            countStr && typeof countStr === 'string'
-              ? parseInt(countStr, 10)
-              : 1
+          const count = parsePositiveInteger(countStr, 'count') ?? 1
           cart.incrementItem(itemId, { count })
 
           return { status: 'success', error: null, itemId }
@@ -240,10 +298,7 @@ export function useCartActions() {
             }
           }
 
-          const count =
-            countStr && typeof countStr === 'string'
-              ? parseInt(countStr, 10)
-              : 1
+          const count = parsePositiveInteger(countStr, 'count') ?? 1
           cart.decrementItem(itemId, { count })
 
           return { status: 'success', error: null, itemId }

--- a/use-shopping-cart/react/useOptimisticCart.test.jsx
+++ b/use-shopping-cart/react/useOptimisticCart.test.jsx
@@ -269,10 +269,9 @@ describe('useOptimisticCart', () => {
     expect(ids[1]).not.toBe('')
     expect(ids[0]).not.toBe(ids[1])
 
-    // The IDs should also be assigned to the original product objects
-    expect(productWithoutId1.id).toBeDefined()
-    expect(productWithoutId2.id).toBeDefined()
-    expect(productWithoutId1.id).not.toBe(productWithoutId2.id)
+    // The product objects should remain unmutated
+    expect(productWithoutId1.id).toBeUndefined()
+    expect(productWithoutId2.id).toBeUndefined()
   })
 
   test('should reconcile optimistic state with real state for products without IDs', async () => {
@@ -293,14 +292,17 @@ describe('useOptimisticCart', () => {
       expect(result.current.cartCount).toBe(1)
     })
 
-    // The product should now have an ID assigned
-    expect(productWithoutId.id).toBeDefined()
-    expect(typeof productWithoutId.id).toBe('string')
-    expect(productWithoutId.id.length).toBeGreaterThan(0)
+    const cartEntries = Object.values(result.current.cartDetails)
+    expect(cartEntries.length).toBe(1)
 
-    // The cart should use this same ID
-    expect(result.current.cartDetails[productWithoutId.id]).toBeDefined()
-    expect(result.current.cartDetails[productWithoutId.id].quantity).toBe(1)
+    const [cartEntry] = cartEntries
+    expect(cartEntry.id).toBeDefined()
+    expect(typeof cartEntry.id).toBe('string')
+    expect(cartEntry.id.length).toBeGreaterThan(0)
+
+    // The cart should use this generated ID
+    expect(result.current.cartDetails[cartEntry.id]).toBeDefined()
+    expect(result.current.cartDetails[cartEntry.id].quantity).toBe(1)
 
     // isOptimistic should be false after the real state is reconciled
     await waitFor(() => {

--- a/use-shopping-cart/utilities/serverless.js
+++ b/use-shopping-cart/utilities/serverless.js
@@ -1,11 +1,23 @@
 function validateCartItems(inventorySrc, cartDetails) {
   const validatedItems = []
 
+  if (!inventorySrc || typeof inventorySrc[Symbol.iterator] !== 'function') {
+    throw new Error('Invalid Cart: inventory must be an iterable collection.')
+  }
+
+  if (!cartDetails || typeof cartDetails !== 'object') {
+    throw new Error('Invalid Cart: cartDetails must be an object.')
+  }
+
   // Build a Map for O(1) lookups instead of O(n) find() calls
   // Only set a key if it doesn't exist to preserve "first match wins" semantics
   // from the original find() implementation
   const inventoryMap = new Map()
   for (const product of inventorySrc) {
+    if (!product || typeof product !== 'object') {
+      throw new Error('Invalid Cart: inventory items must be objects.')
+    }
+
     if (product.id && !inventoryMap.has(product.id)) {
       inventoryMap.set(product.id, product)
     }
@@ -15,6 +27,11 @@ function validateCartItems(inventorySrc, cartDetails) {
   }
 
   for (const id in cartDetails) {
+    const cartItem = cartDetails[id]
+    if (!cartItem || typeof cartItem !== 'object') {
+      throw new Error(`Invalid Cart: cart item "${id}" must be an object.`)
+    }
+
     const inventoryItem = inventoryMap.get(id)
     if (inventoryItem === undefined) {
       throw new Error(
@@ -23,7 +40,7 @@ function validateCartItems(inventorySrc, cartDetails) {
     }
 
     // Validate quantity is a positive integer
-    const quantity = cartDetails[id].quantity
+    const quantity = cartItem.quantity
     if (
       typeof quantity !== 'number' ||
       !Number.isInteger(quantity) ||
@@ -44,16 +61,16 @@ function validateCartItems(inventorySrc, cartDetails) {
         },
         ...inventoryItem.price_data
       },
-      quantity: cartDetails[id].quantity
+      quantity
     }
 
     if (
-      cartDetails[id].product_data &&
-      typeof cartDetails[id].product_data.metadata === 'object'
+      cartItem.product_data &&
+      typeof cartItem.product_data.metadata === 'object'
     ) {
       item.price_data.product_data.metadata = {
         ...item.price_data.product_data.metadata,
-        ...cartDetails[id].product_data.metadata
+        ...cartItem.product_data.metadata
       }
     }
 

--- a/use-shopping-cart/utilities/serverless.test.js
+++ b/use-shopping-cart/utilities/serverless.test.js
@@ -211,6 +211,30 @@ describe('validateCartItems', () => {
     )
   })
 
+  it('throws an error when inventory is not iterable', () => {
+    expect(() => {
+      validateCartItems(null, cartDetails)
+    }).toThrow('Invalid Cart: inventory must be an iterable collection.')
+  })
+
+  it('throws an error when cartDetails is not an object', () => {
+    expect(() => {
+      validateCartItems(inventory, null)
+    }).toThrow('Invalid Cart: cartDetails must be an object.')
+  })
+
+  it('throws an error when cart items are not objects', () => {
+    expect(() => {
+      validateCartItems(inventory, { bad: 'item' })
+    }).toThrow('Invalid Cart: cart item "bad" must be an object.')
+  })
+
+  it('throws an error when inventory items are not objects', () => {
+    expect(() => {
+      validateCartItems([null], cartDetails)
+    }).toThrow('Invalid Cart: inventory items must be objects.')
+  })
+
   it('returns first match when inventory has overlapping id and sku values across products', () => {
     // ProductA has sku: 'ABC', ProductB has id: 'ABC'
     // The first match (ProductA via sku) should win


### PR DESCRIPTION
## Summary
- enforce integer-only counts/quantities and stricter form parsing
- avoid mutating products when generating IDs and keep generated IDs stable
- persist currency/language with stored cart state, plus stronger serverless input validation

## Testing
- pnpm -C use-shopping-cart test
