### PR TITLE
Update docs for integer cart quantities

### DIFF
--- a/docs/content/docs/actions/addItem.mdx
+++ b/docs/content/docs/actions/addItem.mdx
@@ -56,7 +56,7 @@ function ProductCard({ product }: { product: Product }) {
 
 ## Adding with Custom Quantity
 
-You can add multiple items at once by passing a `count` option:
+You can add multiple items at once by passing a `count` option (positive integers only):
 
 ```typescript
 // Add 10 items at once
@@ -87,6 +87,7 @@ See the [metadata example](/docs/examples/metadata) for a complete implementatio
 
 - **SKU vs ID**: `sku` and `id` are interchangeable for backwards compatibility, but `id` is preferred (SKU API is deprecated by Stripe)
 - The product must include at minimum: `id`, `name`, `price`, and `currency`
+- `count` must be a positive integer
 - Metadata is optional and useful for tracking, analytics, or custom business logic
 
 ## Interactive Demo

--- a/docs/content/docs/actions/decrementItem.mdx
+++ b/docs/content/docs/actions/decrementItem.mdx
@@ -27,7 +27,7 @@ function CartItem({ itemId }: { itemId: string }) {
 
 ## Decrement by Custom Amount
 
-You can decrease the quantity by more than 1:
+You can decrease the quantity by more than 1 (positive integers only):
 
 ```typescript
 // Decrease by 10
@@ -63,7 +63,7 @@ function Cart() {
 ## Notes
 
 - Automatically removes item from cart when quantity reaches 0
-- Safe to decrement below 0 (just removes the item)
+- Counts must be positive integers
 
 ## Interactive Demo
 

--- a/docs/content/docs/actions/incrementItem.mdx
+++ b/docs/content/docs/actions/incrementItem.mdx
@@ -27,7 +27,7 @@ function CartItem({ itemId }: { itemId: string }) {
 
 ## Increment by Custom Amount
 
-You can increase the quantity by more than 1:
+You can increase the quantity by more than 1 (positive integers only):
 
 ```typescript
 // Increase by 10

--- a/docs/content/docs/actions/setItemQuantity.mdx
+++ b/docs/content/docs/actions/setItemQuantity.mdx
@@ -3,7 +3,7 @@ title: setItemQuantity()
 id: set-item-quantity
 ---
 
-Sets an item's quantity to a specific number. If set to 0, the item is removed from the cart.
+Sets an item's quantity to a specific integer. If set to 0, the item is removed from the cart.
 
 ## Basic Usage
 
@@ -92,6 +92,7 @@ function Cart() {
 
 ## Notes
 
+- Quantity must be a non-negative integer
 - Setting quantity to 0 removes the item from cart
 - Useful for quantity pickers and dropdowns
 - Replaces the current quantity (doesn't add or subtract)

--- a/docs/content/docs/concepts/persistence.mdx
+++ b/docs/content/docs/concepts/persistence.mdx
@@ -211,11 +211,13 @@ Only cart-specific data is persisted to localStorage:
   cartDetails: { /* all cart items */ },
   cartCount: number,
   totalPrice: number,
-  formattedTotalPrice: string
+  formattedTotalPrice: string,
+  currency: string,
+  language: string
 }
 ```
 
-Configuration settings (stripe key, mode, etc.) are NOT stored - only the cart items.
+Configuration settings (stripe key, mode, etc.) are NOT stored - only cart state and formatting context.
 
 ## Data Format
 
@@ -227,7 +229,9 @@ The cart data is stored as JSON in localStorage:
 {
   "cartCount": 2,
   "totalPrice": 1200,
+  "formattedTotalPrice": "$12.00",
   "currency": "USD",
+  "language": "en-US",
   "cartDetails": {
     "banana_001": {
       "id": "banana_001",

--- a/docs/content/docs/hooks/useCartActions.mdx
+++ b/docs/content/docs/hooks/useCartActions.mdx
@@ -61,8 +61,8 @@ function ProductCard({ product }) {
 
 **Form fields:**
 
-- `product` (required): JSON string of product object
-- `count` (optional): Number of items to add (default: 1)
+- `product` (required): JSON string of product object (max 50,000 chars)
+- `count` (optional): Positive integer count to add (default: 1)
 
 ```jsx
 <form action={addToCartAction}>
@@ -98,7 +98,7 @@ function ProductCard({ product }) {
 **Form fields:**
 
 - `itemId` (required): ID of the item
-- `quantity` (required): New quantity
+- `quantity` (required): Non-negative integer quantity
 
 ```jsx
 <form action={updateQuantityAction}>
@@ -117,7 +117,7 @@ function ProductCard({ product }) {
 **Form fields:**
 
 - `itemId` (required): ID of the item
-- `count` (optional): Amount to increment (default: 1)
+- `count` (optional): Positive integer amount to increment (default: 1)
 
 #### Decrement Item
 
@@ -128,7 +128,7 @@ function ProductCard({ product }) {
 **Form fields:**
 
 - `itemId` (required): ID of the item
-- `count` (optional): Amount to decrement (default: 1)
+- `count` (optional): Positive integer amount to decrement (default: 1)
 
 #### Clear Cart
 

--- a/docs/content/docs/serverless/validateCartItems.mdx
+++ b/docs/content/docs/serverless/validateCartItems.mdx
@@ -7,7 +7,10 @@ id: validate-cart-items
 
 validateCartItems checks the items in the current cart and compares them with a source of truth to
 make sure that the prices and quantities are correct. This is necessary because it's possible that
-malicious users could manipulate the values of prices in the DOM before sending to `redirectToCheckout`
+malicious users could manipulate the values of prices in the DOM before sending to `redirectToCheckout`.
+
+It also validates input shapes and throws if inventory/cart items are not objects or if the inventory
+source is not iterable.
 
 inventory: Source of truth. This should be the object of products you sell. It can come from anywhere that
 is secure. An API call, or a json file that sits on a server.


### PR DESCRIPTION
## Summary
- document integer-only count/quantity requirements across cart actions
- clarify useCartActions form field constraints and JSON size cap
- document persisted currency/language and serverless input validation

## Testing
- pnpm --filter use-shopping-cart build
- pnpm --filter use-shopping-cart run test
