### PR TITLE
Fix cart normalization and optimistic formatting

### DIFF
--- a/use-shopping-cart/core/ShoppingCart.test.ts
+++ b/use-shopping-cart/core/ShoppingCart.test.ts
@@ -657,6 +657,43 @@ describe('ShoppingCart', () => {
       expect(state.cartCount).toBe(4)
       expect(state.totalPrice).toBe(1000)
     })
+
+    it('normalizes loaded entries missing computed fields', () => {
+      const cart = new ShoppingCart({
+        shouldPersist: false,
+        currency: 'USD',
+        language: 'en-US'
+      })
+
+      const newCartDetails = {
+        'item-1': {
+          id: 'item-1',
+          name: 'Bananas',
+          price: 1000,
+          currency: 'USD',
+          quantity: 2
+        } as any,
+        'item-2': {
+          id: 'item-2',
+          name: 'Carrots',
+          price: 500,
+          currency: 'USD',
+          quantity: 1
+        } as any
+      }
+
+      cart.loadCart(newCartDetails, false)
+
+      const state = cart.getState()
+      expect(state.cartCount).toBe(3)
+      expect(state.totalPrice).toBe(2500)
+      expect(state.formattedTotalPrice).toBe('$25.00')
+      expect(state.cartDetails['item-1'].value).toBe(2000)
+      expect(state.cartDetails['item-1'].formattedValue).toBe('$20.00')
+      expect(state.cartDetails['item-1'].formattedPrice).toBe('$10.00')
+      expect(state.cartDetails['item-2'].formattedValue).toBe('$5.00')
+      expect(state.cartDetails['item-2'].formattedPrice).toBe('$5.00')
+    })
   })
 
   describe('handleCartHover', () => {

--- a/use-shopping-cart/core/ShoppingCart.ts
+++ b/use-shopping-cart/core/ShoppingCart.ts
@@ -166,6 +166,35 @@ export class ShoppingCart {
     )
   }
 
+  private _normalizeCartDetails(
+    cartDetails: CartDetails,
+    currency: string,
+    language: string
+  ): CartDetails {
+    const normalizedCartDetails: CartDetails = {}
+
+    for (const id in cartDetails) {
+      const entry = cartDetails[id]
+      const baseEntry = createCartEntry(
+        id,
+        entry,
+        entry.quantity,
+        {},
+        {},
+        currency,
+        language
+      )
+
+      const normalizedEntry = entry.timestamp
+        ? { ...baseEntry, timestamp: entry.timestamp }
+        : baseEntry
+
+      normalizedCartDetails[id] = normalizedEntry
+    }
+
+    return normalizedCartDetails
+  }
+
   private _parseAndLoadStoredData(stored: string): void {
     try {
       const parsed = JSON.parse(stored)
@@ -525,12 +554,17 @@ export class ShoppingCart {
       newCartDetails = { ...cartDetails }
     }
 
-    const { totalPrice, cartCount } = calculateTotals(newCartDetails)
+    const normalizedCartDetails = this._normalizeCartDetails(
+      newCartDetails,
+      this._state.currency,
+      this._state.language
+    )
+    const { totalPrice, cartCount } = calculateTotals(normalizedCartDetails)
 
     // ✅ IMMUTABLE - single state update
     this._state = {
       ...this._state,
-      cartDetails: newCartDetails,
+      cartDetails: normalizedCartDetails,
       totalPrice,
       cartCount,
       formattedTotalPrice: calculateFormattedTotalPrice(

--- a/use-shopping-cart/react/useOptimisticCart.test.js
+++ b/use-shopping-cart/react/useOptimisticCart.test.js
@@ -11,6 +11,7 @@ const wrapper = ({ children }) => (
     cartMode="client-only"
     stripe="pk_test_123"
     currency="USD"
+    language="en-US"
     shouldPersist={false}
   >
     {children}
@@ -91,6 +92,12 @@ describe('useOptimisticCart', () => {
     // Wait for increment to complete
     await waitFor(() => {
       expect(result.current.cartDetails[mockProduct.id].quantity).toBe(2)
+      expect(result.current.cartDetails[mockProduct.id].formattedValue).toBe(
+        '$20.00'
+      )
+      expect(result.current.cartDetails[mockProduct.id].formattedPrice).toBe(
+        '$10.00'
+      )
     })
   })
 

--- a/use-shopping-cart/react/useOptimisticCart.test.jsx
+++ b/use-shopping-cart/react/useOptimisticCart.test.jsx
@@ -11,6 +11,7 @@ const wrapper = ({ children }) => (
     cartMode="client-only"
     stripe="pk_test_123"
     currency="USD"
+    language="en-US"
     shouldPersist={false}
   >
     {children}
@@ -91,6 +92,12 @@ describe('useOptimisticCart', () => {
     // Wait for increment to complete
     await waitFor(() => {
       expect(result.current.cartDetails[mockProduct.id].quantity).toBe(2)
+      expect(result.current.cartDetails[mockProduct.id].formattedValue).toBe(
+        '$20.00'
+      )
+      expect(result.current.cartDetails[mockProduct.id].formattedPrice).toBe(
+        '$10.00'
+      )
     })
   })
 

--- a/use-shopping-cart/react/useOptimisticCart.tsx
+++ b/use-shopping-cart/react/useOptimisticCart.tsx
@@ -92,12 +92,24 @@ export function useOptimisticCart() {
 
         // Item already exists - increment it
         if (state[id]) {
+          const nextQuantity = state[id].quantity + count
+          const nextValue = state[id].price * nextQuantity
           return {
             ...state,
             [id]: {
               ...state[id],
-              quantity: state[id].quantity + count,
-              value: state[id].price * (state[id].quantity + count),
+              quantity: nextQuantity,
+              value: nextValue,
+              formattedValue: formatPrice(
+                nextValue,
+                cart.currency,
+                cart.language
+              ),
+              formattedPrice: formatPrice(
+                state[id].price,
+                cart.currency,
+                cart.language
+              ),
               _optimistic: true
             }
           }
@@ -139,12 +151,25 @@ export function useOptimisticCart() {
         const { id, count = 1 } = action
         if (!state[id]) return state
 
+        const nextQuantity = state[id].quantity + count
+        const nextValue = state[id].price * nextQuantity
+
         return {
           ...state,
           [id]: {
             ...state[id],
-            quantity: state[id].quantity + count,
-            value: state[id].price * (state[id].quantity + count),
+            quantity: nextQuantity,
+            value: nextValue,
+            formattedValue: formatPrice(
+              nextValue,
+              cart.currency,
+              cart.language
+            ),
+            formattedPrice: formatPrice(
+              state[id].price,
+              cart.currency,
+              cart.language
+            ),
             _optimistic: true
           }
         }
@@ -162,12 +187,24 @@ export function useOptimisticCart() {
           return rest
         }
 
+        const nextValue = state[id].price * newQuantity
+
         return {
           ...state,
           [id]: {
             ...state[id],
             quantity: newQuantity,
-            value: state[id].price * newQuantity,
+            value: nextValue,
+            formattedValue: formatPrice(
+              nextValue,
+              cart.currency,
+              cart.language
+            ),
+            formattedPrice: formatPrice(
+              state[id].price,
+              cart.currency,
+              cart.language
+            ),
             _optimistic: true
           }
         }
@@ -183,12 +220,24 @@ export function useOptimisticCart() {
           return rest
         }
 
+        const nextValue = state[id].price * quantity
+
         return {
           ...state,
           [id]: {
             ...state[id],
             quantity,
-            value: state[id].price * quantity,
+            value: nextValue,
+            formattedValue: formatPrice(
+              nextValue,
+              cart.currency,
+              cart.language
+            ),
+            formattedPrice: formatPrice(
+              state[id].price,
+              cart.currency,
+              cart.language
+            ),
             _optimistic: true
           }
         }


### PR DESCRIPTION
## Summary
- Normalize loaded cart entries to compute value and formatted fields with the active currency/language.
- Recompute formatted line item values during optimistic quantity updates.
- Add regression tests for loadCart normalization and optimistic formatting.

## Testing
- pnpm --filter use-shopping-cart build
- pnpm --filter use-shopping-cart test