### PR TITLE
chore: align v4 rc docs and npm dist-tags

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -58,11 +58,27 @@ jobs:
       - name: Publish to npm
         working-directory: use-shopping-cart
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            npm publish --dry-run --tag alpha
-          else
-            npm publish --tag alpha
+          VERSION="$(node -p \"require('./package.json').version\")"
+          DIST_TAG="latest"
+
+          if [[ "$VERSION" == *"-"* ]]; then
+            DIST_TAG="${VERSION#*-}"
+            DIST_TAG="${DIST_TAG%%.*}"
           fi
+
+          echo "Publishing use-shopping-cart@$VERSION with dist-tag: $DIST_TAG"
+
+          PUBLISH_ARGS=()
+          if [[ "$DIST_TAG" != "latest" ]]; then
+            PUBLISH_ARGS+=(--tag "$DIST_TAG")
+          fi
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            npm publish --dry-run "${PUBLISH_ARGS[@]}"
+          else
+            npm publish "${PUBLISH_ARGS[@]}"
+          fi
+
 #   publish-gpr:
 #     needs: build
 #     runs-on: ubuntu-latest

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,6 +11,7 @@ Version 4.0.0 is a major update that brings React 19 support and several importa
 use-shopping-cart v4.0.0 requires React 19 as a peer dependency.
 
 **Before (v3.x):**
+
 ```json
 {
   "dependencies": {
@@ -22,6 +23,7 @@ use-shopping-cart v4.0.0 requires React 19 as a peer dependency.
 ```
 
 **After (v4.x):**
+
 ```json
 {
   "dependencies": {
@@ -46,12 +48,14 @@ Node.js 18 or higher is now required (previously Node.js 8+).
 In v3.x, the `CartProvider` would recreate the Redux store every time props changed, which could cause unexpected behavior. This has been fixed in v4.0.0.
 
 **What this means for you:**
+
 - Your cart state should be more stable
 - No action required on your part - this fix is automatic
 
 #### Updated Dependencies
 
 All dependencies have been updated to their latest versions:
+
 - TypeScript 5.3
 - Jest 29
 - ESLint 9
@@ -81,11 +85,11 @@ yarn add react@^19.0.0 react-dom@^19.0.0
 #### 2. Update use-shopping-cart
 
 ```bash
-npm install use-shopping-cart@^4.0.0
+npm install use-shopping-cart@rc
 # or
-pnpm add use-shopping-cart@^4.0.0
+pnpm add use-shopping-cart@rc
 # or
-yarn add use-shopping-cart@^4.0.0
+yarn add use-shopping-cart@rc
 ```
 
 #### 3. Run React 19 Codemods (Optional)
@@ -97,6 +101,7 @@ npx codemod@latest react/19/migration-recipe
 ```
 
 This will automatically update deprecated APIs like:
+
 - `ReactDOM.render` → `ReactDOM.createRoot`
 - String refs → Ref callbacks
 - And more...
@@ -126,6 +131,7 @@ npm test
 #### Issue: Type errors with refs
 
 **Error:**
+
 ```
 Cannot assign to 'current' because it is a read-only property
 ```
@@ -144,6 +150,7 @@ const ref = useRef<HTMLDivElement>(null)
 #### Issue: Test failures with `act`
 
 **Error:**
+
 ```
 Cannot find module 'react-dom/test-utils'
 ```
@@ -178,16 +185,18 @@ While v4.0.0 is primarily focused on React 19 compatibility, it includes several
 3. **Modern Dependencies**: All dependencies updated to latest stable versions
 4. **Improved TypeScript**: Better type definitions and React 19 compatibility
 
-### What's Next?
+### Release Status
 
-We're continuing work on v4.0.0 with these upcoming features:
+`v4.0.0-rc.1` is the current release candidate.
 
-- **Redux Removal (Coming in v4.0.0)**: Replace Redux with a lightweight class-based cart
-- **Full TypeScript Migration**: Convert entire codebase from JavaScript to TypeScript
-- **Smaller Bundle Size**: Reduce bundle size by ~70% by removing Redux
-- **Framework Agnostic Core**: Use the cart with React, Vue, Svelte, or vanilla JS
+Completed v4 work includes:
 
-The React 19 upgrade you just completed is the first step. Stay tuned for the complete v4.0.0 release!
+- React 19 support
+- Redux removal in favor of a class-based cart core
+- TypeScript migration across the core and React bindings
+- Updated tests, tooling, and docs for the new architecture
+
+The final v4.0.0 release is focused on release hardening, CI validation, and documentation polish.
 
 ### Getting Help
 
@@ -211,6 +220,5 @@ yarn add use-shopping-cart@^3.2.0 react@^18.2.0 react-dom@^18.2.0
 
 ---
 
-**Last Updated:** December 2024
-**Version:** 4.0.0
-
+**Last Updated:** February 2026
+**Version:** 4.0.0-rc.1

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
 
 > A React Hook that handles shopping cart state and logic for Stripe.
 
-**⚠️ v4.0.0-alpha requires React 19** - If you're using React 18, please use [v3.x](https://github.com/dayhaysoos/use-shopping-cart/tree/v3.2.0).
+**⚠️ v4 requires React 19** - If you're using React 18, please use [v3.x](https://github.com/dayhaysoos/use-shopping-cart/tree/v3.2.0).
 
-> **Note:** v4.0.0 is under active development. The React 19 upgrade is complete, with Redux removal and TypeScript migration coming soon.
+> **Note:** `v4.0.0-rc.1` is the current release candidate. React 19 support is complete, and v4 now uses the class-based cart architecture.
 
 https://useshoppingcart.com
 
@@ -28,11 +28,11 @@ Click to open gist.
 ## Installation
 
 ```bash
-npm install use-shopping-cart
+npm install use-shopping-cart@rc
 # or
-pnpm add use-shopping-cart
+pnpm add use-shopping-cart@rc
 # or
-yarn add use-shopping-cart
+yarn add use-shopping-cart@rc
 ```
 
 **Requirements:**

--- a/docs/content/docs/getting-started.mdx
+++ b/docs/content/docs/getting-started.mdx
@@ -8,13 +8,13 @@ Get up and running with use-shopping-cart in minutes.
 ## Installation
 
 ```bash
-npm install use-shopping-cart@next
+npm install use-shopping-cart@rc
 
 # or
-yarn add use-shopping-cart@next
+yarn add use-shopping-cart@rc
 
 # or
-pnpm add use-shopping-cart@next
+pnpm add use-shopping-cart@rc
 ```
 
 ## Requirements

--- a/docs/content/docs/migration-v4.mdx
+++ b/docs/content/docs/migration-v4.mdx
@@ -21,13 +21,13 @@ Version 4.0 brings significant improvements while maintaining 100% backward comp
 ### Installation
 
 ```bash
-npm install use-shopping-cart@next
+npm install use-shopping-cart@rc
 
 # or
-yarn add use-shopping-cart@next
+yarn add use-shopping-cart@rc
 
 # or
-pnpm add use-shopping-cart@next
+pnpm add use-shopping-cart@rc
 ```
 
 ### Dependencies
@@ -230,7 +230,7 @@ All existing APIs continue to work:
 ### Step 1: Update Dependencies
 
 ```bash
-npm install use-shopping-cart@next react@19 react-dom@19
+npm install use-shopping-cart@rc react@19 react-dom@19
 ```
 
 ### Step 2: Test Your Application

--- a/docs/content/docs/welcome/migration-v4.mdx
+++ b/docs/content/docs/welcome/migration-v4.mdx
@@ -21,13 +21,13 @@ Version 4.0 brings significant improvements while maintaining 100% backward comp
 ### Installation
 
 ```bash
-npm install use-shopping-cart@next
+npm install use-shopping-cart@rc
 
 # or
-yarn add use-shopping-cart@next
+yarn add use-shopping-cart@rc
 
 # or
-pnpm add use-shopping-cart@next
+pnpm add use-shopping-cart@rc
 ```
 
 ### Dependencies
@@ -230,7 +230,7 @@ All existing APIs continue to work:
 ### Step 1: Update Dependencies
 
 ```bash
-npm install use-shopping-cart@next react@19 react-dom@19
+npm install use-shopping-cart@rc react@19 react-dom@19
 ```
 
 ### Step 2: Test Your Application


### PR DESCRIPTION
Keep release guidance consistent with 4.0.0-rc.1 and publish prereleases using a tag derived from package version.